### PR TITLE
Implement add group fragment

### DIFF
--- a/app/src/main/java/ro/code4/deurgenta/interfaces/ClickButtonCallback.kt
+++ b/app/src/main/java/ro/code4/deurgenta/interfaces/ClickButtonCallback.kt
@@ -4,6 +4,6 @@ package ro.code4.deurgenta.interfaces
 /**
  * Callback for when saving progress.
  */
-interface ClickButtonCallback {
+fun interface ClickButtonCallback {
     fun call()
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/account/ConfigureAccountFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/account/ConfigureAccountFragment.kt
@@ -44,11 +44,13 @@ class ConfigureAccountFragment : ViewModelFragment<ConfigureAccountViewModel>() 
 
     @SuppressLint("LongLogTag")
     private fun configureCallbacks() {
-        viewBinding.callbackAddresses = object : ClickButtonCallback {
-            override fun call() {
-                val directions = ConfigureAccountFragmentDirections.actionConfigureAddress(mapAddressType = MapAddressType.HOME, R.string.add_home_address)
-                findNavController().navigate(directions)
-            }
+        viewBinding.callbackAddresses = ClickButtonCallback {
+            val directions = ConfigureAccountFragmentDirections.actionConfigureAddress(mapAddressType = MapAddressType.HOME, R.string.add_home_address)
+            findNavController().navigate(directions)
+        }
+
+        viewBinding.callbackGroup = ClickButtonCallback {
+            findNavController().navigate(R.id.action_configure_group)
         }
     }
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsFragment.kt
@@ -2,6 +2,7 @@ package ro.code4.deurgenta.ui.base
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.koin.android.ext.android.inject
@@ -12,9 +13,13 @@ import ro.code4.deurgenta.helper.logD
 import ro.code4.deurgenta.helper.logW
 import ro.code4.deurgenta.interfaces.AnalyticsScreenName
 
-abstract class BaseAnalyticsFragment : Fragment(), AnalyticsScreenName {
+abstract class BaseAnalyticsFragment : Fragment, AnalyticsScreenName {
 
     private val firebaseAnalytics: FirebaseAnalytics by inject()
+
+    protected constructor() : super()
+
+    protected constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateInfoFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateInfoFragment.kt
@@ -1,0 +1,27 @@
+package ro.code4.deurgenta.ui.group
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.widget.addTextChangedListener
+import kotlinx.android.synthetic.main.fragment_group_create_info.*
+import ro.code4.deurgenta.R
+import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+
+class GroupCreateInfoFragment : BaseAnalyticsFragment(R.layout.fragment_group_create_info) {
+    override val screenName: Int = R.string.analytics_title_group
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        input_group_name.addTextChangedListener {
+            // Allow submission only if name is not blank
+            button_create_new_group_continue.isEnabled = !it.isNullOrEmpty()
+        }
+
+        button_create_new_group_continue.setOnClickListener {
+            val name = input_group_name.text.toString()
+
+            // TODO: create new group with the given name
+        }
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateLandingFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateLandingFragment.kt
@@ -1,0 +1,26 @@
+package ro.code4.deurgenta.ui.group
+
+import android.graphics.Paint
+import android.os.Bundle
+import android.view.View
+import androidx.navigation.fragment.findNavController
+import kotlinx.android.synthetic.main.fragment_group_create_landing.*
+import ro.code4.deurgenta.R
+import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+
+class GroupCreateLandingFragment : BaseAnalyticsFragment(R.layout.fragment_group_create_landing) {
+    override val screenName: Int = R.string.analytics_title_group
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        button_reject_new_group.paintFlags = button_reject_new_group.paintFlags or Paint.UNDERLINE_TEXT_FLAG
+        button_reject_new_group.setOnClickListener {
+            findNavController().navigateUp()
+        }
+
+        button_create_new_group.setOnClickListener {
+            findNavController().navigate(R.id.action_groupCreateLandingFragment_to_groupCreateInfoFragment)
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_configure_account.xml
+++ b/app/src/main/res/layout/fragment_configure_account.xml
@@ -9,6 +9,9 @@
             name="callbackAddresses"
             type="ro.code4.deurgenta.interfaces.ClickButtonCallback" />
 
+        <variable
+            name="callbackGroup"
+            type="ro.code4.deurgenta.interfaces.ClickButtonCallback" />
     </data>
 
     <ScrollView
@@ -85,7 +88,7 @@
                     android:id="@+id/create_group"
                     style="@style/MenuTextView"
                     android:background="?android:attr/selectableItemBackground"
-
+                    android:onClick="@{() -> callbackGroup.call()}"
                     android:padding="@dimen/padding"
                     android:text="@string/create_your_group"
                     android:textAppearance="@style/Text.MenuList"

--- a/app/src/main/res/layout/fragment_group_create_info.xml
+++ b/app/src/main/res/layout/fragment_group_create_info.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="30dp"
+            android:text="@string/group_create_info_title"
+            android:textColor="@color/design_default_color_on_secondary"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <TextView
+            style="@style/Input.Label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/group_name_label" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginBottom="@dimen/big_margin"
+            android:layout_weight="1"
+            app:hintTextColor="@color/design_default_color_on_secondary">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_group_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/group_name_hint"
+                android:inputType="none"
+                android:selectAllOnFocus="true"
+                android:singleLine="true"
+                android:textColor="@color/design_default_color_on_secondary"
+                android:textColorHint="@color/design_default_color_on_secondary"
+                app:backgroundTint="@color/cardview_dark_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_create_new_group_continue"
+            style="@style/Signup.Button.Simple"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/big_margin"
+            android:text="@string/group_continue_button_label"
+            android:textAllCaps="false"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_group_create_info.xml
+++ b/app/src/main/res/layout/fragment_group_create_info.xml
@@ -12,13 +12,12 @@
         android:orientation="vertical">
 
         <TextView
+            style="@style/Text.Big"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="30dp"
+            android:layout_marginBottom="@dimen/xbig_margin"
             android:text="@string/group_create_info_title"
-            android:textColor="@color/design_default_color_on_secondary"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            android:textColor="@color/design_default_color_on_secondary" />
 
         <TextView
             style="@style/Input.Label"
@@ -44,9 +43,7 @@
                 android:singleLine="true"
                 android:textColor="@color/design_default_color_on_secondary"
                 android:textColorHint="@color/design_default_color_on_secondary"
-                app:backgroundTint="@color/cardview_dark_background"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:backgroundTint="@color/cardview_dark_background" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -56,11 +53,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/big_margin"
-            android:text="@string/group_continue_button_label"
-            android:textAllCaps="false"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            android:text="@string/group_continue_button_label" />
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_group_create_landing.xml
+++ b/app/src/main/res/layout/fragment_group_create_landing.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/margin"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+
+        <TextView
+            style="@style/Text.SectionHeading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20sp"
+            android:text="@string/group_create_title"
+            android:textColor="@color/design_default_color_on_secondary"
+            android:textSize="24sp" />
+
+        <TextView
+            style="@style/Text.Paragraph"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24sp"
+            android:text="@string/group_create_info_1" />
+
+        <TextView
+            style="@style/Text.Paragraph"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/group_create_info_2"
+            android:textSize="16sp"
+            app:lineHeight="24sp" />
+
+        <TextView
+            android:id="@+id/button_reject_new_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20sp"
+            android:text="@string/group_create_reject"
+            android:textAlignment="center"
+            android:textSize="16sp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_create_new_group"
+            style="@style/Signup.Button.Simple"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/group_create_button_label" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_group_create_landing.xml
+++ b/app/src/main/res/layout/fragment_group_create_landing.xml
@@ -16,16 +16,15 @@
             style="@style/Text.SectionHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20sp"
+            android:layout_marginBottom="@dimen/big_margin"
             android:text="@string/group_create_title"
-            android:textColor="@color/design_default_color_on_secondary"
-            android:textSize="24sp" />
+            android:textColor="@color/design_default_color_on_secondary" />
 
         <TextView
             style="@style/Text.Paragraph"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="24sp"
+            android:layout_marginBottom="@dimen/big_margin"
             android:text="@string/group_create_info_1" />
 
         <TextView
@@ -33,18 +32,16 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/group_create_info_2"
-            android:textSize="16sp"
-            app:lineHeight="24sp" />
+            android:text="@string/group_create_info_2" />
 
         <TextView
             android:id="@+id/button_reject_new_group"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20sp"
+            android:layout_marginBottom="@dimen/big_margin"
             android:text="@string/group_create_reject"
             android:textAlignment="center"
-            android:textSize="16sp" />
+            android:textSize="@dimen/text_size" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/button_create_new_group"

--- a/app/src/main/res/navigation/navigation_group.xml
+++ b/app/src/main/res/navigation/navigation_group.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" android:id="@+id/navigation_group"
+    app:startDestination="@id/groupCreateLandingFragment">
+
+    <fragment
+        android:id="@+id/groupCreateLandingFragment"
+        android:name="ro.code4.deurgenta.ui.group.GroupCreateLandingFragment"
+        android:label="GroupCreateLandingFragment" >
+        <action
+            android:id="@+id/action_groupCreateLandingFragment_to_groupCreateInfoFragment"
+            app:destination="@id/groupCreateInfoFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/groupCreateInfoFragment"
+        android:name="ro.code4.deurgenta.ui.group.GroupCreateInfoFragment"
+        android:label="GroupCreateInfoFragment" />
+</navigation>

--- a/app/src/main/res/navigation/onboard_graph.xml
+++ b/app/src/main/res/navigation/onboard_graph.xml
@@ -20,8 +20,12 @@
                 android:name="titleResourceId"
                 app:argType="integer" />
         </action>
+        <action
+            android:id="@+id/action_configure_group"
+            app:destination="@id/navigation_group" />
     </fragment>
 
     <include app:graph="@navigation/configure_addresses" />
+    <include app:graph="@navigation/navigation_group" />
 
 </navigation>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -109,6 +109,15 @@
     <string name="edit_backpack_item_error_name">Introdu numele produsului!</string>
     <string name="edit_backpack_item_error_quantity">Introdu cantitatea produsului!</string>
     <string name="edit_backpack_item_error_quantity_value">"Introdu un numar pentru cantitate!"</string>
+    <string name="group_create_title">Creează-ți un grup</string>
+    <string name="group_create_info_1">În eventualitatea unui cutremur este important sa ai un protocol împreună cu cei apropiați prin care vă puteți regăsi cu ușurință. Creează un grup de prieteni, de familie sau de colegi de la birou sau școală pentru a vă seta puncte de întâlnire în caz de cutremur.</string>
+    <string name="group_create_info_2">Chiar dacă nu vei avea acces la internet în acele momente, poți folosi în continuare aplicația pentru a vedea care sunt punctele de întâlnire și pentru a identifica traseele pentru a ajunge acolo. De asemenea, poți vedea, cu permisiunea lor, traseele și adresele uzuale ale membrilor grupului tău și îi poți căuta dacă aceștia nu vin la punctul de întâlnire.</string>
+    <string name="group_create_reject">Nu vreau să creez un grup acum</string>
+    <string name="group_create_button_label">Creează un grup nou</string>
+    <string name="group_continue_button_label">Continuă</string>
+    <string name="group_create_info_title">Creează-ți grupul de prieteni</string>
+    <string name="group_name_label">Denumirea grupului</string>
+    <string name="group_name_hint">Fii creativ…</string>
 
     <!-- Configure account -->
     <string name="configure_addresses">Configureaza adresele</string>

--- a/app/src/main/res/values/analytics_strings.xml
+++ b/app/src/main/res/values/analytics_strings.xml
@@ -5,4 +5,5 @@
     <string name="analytics_title_login" translatable="false">Login</string>
     <string name="analytics_title_home" translatable="false">Home</string>
     <string name="analytics_title_backpack" translatable="false">Your emergency backpack</string>
+    <string name="analytics_title_group" translatable="false">Group</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,17 @@
     <string name="edit_backpack_item_error_quantity">Please provide a quantity</string>
     <string name="edit_backpack_item_error_quantity_value">"Please enter a valid number quantity!"</string>
 
+    <!-- Group -->
+    <string name="group_create_title">Create a group</string>
+    <string name="group_create_info_1">În eventualitatea unui cutremur este important sa ai un protocol împreună cu cei apropiați prin care vă puteți regăsi cu ușurință. Creează un grup de prieteni, de familie sau de colegi de la birou sau școală pentru a vă seta puncte de întâlnire în caz de cutremur.</string>
+    <string name="group_create_info_2">Chiar dacă nu vei avea acces la internet în acele momente, poți folosi în continuare aplicația pentru a vedea care sunt punctele de întâlnire și pentru a identifica traseele pentru a ajunge acolo. De asemenea, poți vedea, cu permisiunea lor, traseele și adresele uzuale ale membrilor grupului tău și îi poți căuta dacă aceștia nu vin la punctul de întâlnire.</string>
+    <string name="group_create_reject">I don\'t want to create a group now</string>
+    <string name="group_create_button_label">Create a new group</string>
+    <string name="group_continue_button_label">Continue</string>
+    <string name="group_create_info_title">Create your group of friends</string>
+    <string name="group_name_label">Group name</string>
+    <string name="group_name_hint">Be creative…</string>
+
     <!-- Configure account -->
     <string name="configure_addresses">Configure Addresses</string>
     <string name="create_your_account">Configure your account</string>
@@ -156,5 +167,4 @@
     <string name="unknown_error" translatable="false">Unknown</string>
     <string name="item_address_header" translatable="false">address_title</string>
     <string name="item_address_content" translatable="false">address_name</string>
-
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -55,10 +55,19 @@
         <item name="android:textSize">24sp</item>
     </style>
 
+    <style name="Text.SectionHeading">
+        <item name="android:textColor">@color/gray_800</item>
+        <item name="android:textSize">24sp</item>
+        <item name="lineHeight">30sp</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="fontWeight">700</item>
+    </style>
+
     <style name="Text.Paragraph">
         <item name="android:textSize">16sp</item>
         <item name="android:textColor">@color/gray_800</item>
         <item name="lineHeight">26sp</item>
+        <item name="android:fontFamily">sans-serif</item>
     </style>
 
     <style name="Text.MenuList">


### PR DESCRIPTION
### What does it fix?

Closes #40 
Closes #41

Implements the first two screens of the group creation flow.

![image](https://user-images.githubusercontent.com/3010346/116593496-d2c7e100-a929-11eb-8f8d-6941c6866eaa.png)
![image](https://user-images.githubusercontent.com/3010346/116593541-dc514900-a929-11eb-8bbc-246794262c09.png)

Navigation between the first and second fragment also works.

I didn't see a reason to use a view model for the first fragment (since it only displays a message and some navigation buttons), so I made them inherit the `BaseAnalyticsFragment` and also gave it a constructor which allows passing in a content layout.

### How has it been tested?

Ran it locally on a device emulator.

