### PR TITLE
Update plugins usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.sonarqube'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
@@ -16,10 +16,6 @@ static def getKey(String env, String key) {
 
 static def asString(String field) {
     return "\"${field}\""
-}
-
-androidExtensions {
-    experimental true
 }
 
 android {
@@ -46,6 +42,7 @@ android {
 
     buildFeatures {
         dataBinding true
+        viewBinding true
     }
 
     sourceSets {
@@ -149,7 +146,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
 
-
+    implementation "com.github.Zhuinden:fragmentviewbindingdelegate-kt:$viewBindingDelegateVersion"
     implementation platform("com.squareup.okhttp3:okhttp-bom:4.9.0")
     implementation "com.squareup.okhttp3:okhttp"
     implementation "com.squareup.okhttp3:logging-interceptor"
@@ -166,10 +163,6 @@ dependencies {
     implementation "io.insert-koin:koin-core:$koinVersion"
     implementation "io.insert-koin:koin-android:$koinVersion"
     implementation "io.insert-koin:koin-android-viewmodel:$koinVersion"
-
-    // Parceler
-    implementation "org.parceler:parceler-api:$parcelerVersion"
-    kapt "org.parceler:parceler:$parcelerVersion"
 
     // Room
     implementation "androidx.room:room-runtime:$roomVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,6 @@ android {
 }
 
 
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'], exclude: ['*mock*.jar'])
 
@@ -159,9 +158,9 @@ dependencies {
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
 
-    // Firebase
-    implementation "com.google.firebase:firebase-analytics:$firebaseAnalyticsVersion"
-    implementation "com.google.firebase:firebase-crashlytics:$firebaseCrashlyticsVersion"
+    implementation platform("com.google.firebase:firebase-bom:$firebaseVersion")
+    implementation "com.google.firebase:firebase-analytics-ktx"
+    implementation "com.google.firebase:firebase-crashlytics-ktx"
 
     // Koin injection
     implementation "io.insert-koin:koin-core:$koinVersion"

--- a/app/src/main/java/ro/code4/deurgenta/data/model/Backpack.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/Backpack.kt
@@ -5,7 +5,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.Expose
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Entity(tableName = Backpack.TABLE_NAME)
 @Parcelize

--- a/app/src/main/java/ro/code4/deurgenta/data/model/BackpackItem.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/BackpackItem.kt
@@ -2,7 +2,7 @@ package ro.code4.deurgenta.data.model
 
 import android.os.Parcelable
 import androidx.room.*
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.threeten.bp.ZonedDateTime
 
 

--- a/app/src/main/java/ro/code4/deurgenta/data/model/BackpackItemType.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/BackpackItemType.kt
@@ -1,7 +1,7 @@
 package ro.code4.deurgenta.data.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Possible categories:

--- a/app/src/main/java/ro/code4/deurgenta/data/model/Course.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/Course.kt
@@ -2,7 +2,7 @@ package ro.code4.deurgenta.data.model
 
 import android.os.Parcelable
 import androidx.room.*
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.threeten.bp.ZonedDateTime
 
 @Entity(tableName = Course.TABLE_NAME)

--- a/app/src/main/java/ro/code4/deurgenta/data/model/MapAddress.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/MapAddress.kt
@@ -5,7 +5,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverter
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Entity(
     tableName = MapAddress.TABLE_NAME

--- a/app/src/main/java/ro/code4/deurgenta/data/model/MapAddressType.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/MapAddressType.kt
@@ -1,7 +1,7 @@
 package ro.code4.deurgenta.data.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Possible address types:

--- a/app/src/main/java/ro/code4/deurgenta/modules/Modules.kt
+++ b/app/src/main/java/ro/code4/deurgenta/modules/Modules.kt
@@ -2,11 +2,8 @@ package ro.code4.deurgenta.modules
 
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -28,12 +25,14 @@ import ro.code4.deurgenta.repositories.AccountRepository
 import ro.code4.deurgenta.repositories.AccountRepositoryImpl
 import ro.code4.deurgenta.repositories.Repository
 import ro.code4.deurgenta.services.AccountService
+import ro.code4.deurgenta.services.AnalyticsService
+import ro.code4.deurgenta.services.FirebaseAnalyticsService
 import ro.code4.deurgenta.ui.address.ConfigureAddressViewModel
 import ro.code4.deurgenta.ui.address.SaveAddressViewModel
 import ro.code4.deurgenta.ui.auth.AuthViewModel
 import ro.code4.deurgenta.ui.auth.login.LoginFormViewModel
-import ro.code4.deurgenta.ui.auth.reset.ResetPasswordViewModel
 import ro.code4.deurgenta.ui.auth.register.RegisterViewModel
+import ro.code4.deurgenta.ui.auth.reset.ResetPasswordViewModel
 import ro.code4.deurgenta.ui.backpack.edit.EditBackpackItemViewModel
 import ro.code4.deurgenta.ui.backpack.items.BackpackItemsViewModel
 import ro.code4.deurgenta.ui.backpack.main.BackpackDetailsViewModel
@@ -44,6 +43,8 @@ import ro.code4.deurgenta.ui.home.HomeViewModel
 import ro.code4.deurgenta.ui.main.MainViewModel
 import ro.code4.deurgenta.ui.onboarding.OnboardingViewModel
 import ro.code4.deurgenta.ui.splashscreen.SplashScreenViewModel
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 val gson: Gson by lazy {
     val gsonBuilder = GsonBuilder()
@@ -133,5 +134,5 @@ val viewModelsModule = module {
 }
 
 val analyticsModule = module {
-    single { FirebaseAnalytics.getInstance(get()) }
+    single<AnalyticsService> { FirebaseAnalyticsService(get()) }
 }

--- a/app/src/main/java/ro/code4/deurgenta/services/AnalyticsService.kt
+++ b/app/src/main/java/ro/code4/deurgenta/services/AnalyticsService.kt
@@ -1,0 +1,32 @@
+package ro.code4.deurgenta.services
+
+import android.content.Context
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+import ro.code4.deurgenta.analytics.Event
+import ro.code4.deurgenta.analytics.Param
+import ro.code4.deurgenta.helper.logD
+import ro.code4.deurgenta.helper.logW
+
+interface AnalyticsService {
+
+    fun logEvent(event: Event, vararg params: Param)
+}
+
+class FirebaseAnalyticsService(context: Context) : AnalyticsService {
+
+    private val firebaseService = FirebaseAnalytics.getInstance(context)
+
+    override fun logEvent(event: Event, vararg params: Param) {
+        logD("logAnalyticsEvent: ${event.name}")
+        val bundle = Bundle()
+        for ((k, v) in params) {
+            when (v) {
+                is String -> bundle.putString(k.title, v)
+                is Int -> bundle.putInt(k.title, v)
+                else -> logW("Not implemented bundle params for ${v.javaClass}")
+            }
+        }
+        firebaseService.logEvent(event.title, bundle)
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/about/AboutFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/about/AboutFragment.kt
@@ -1,35 +1,36 @@
 package ro.code4.deurgenta.ui.about
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_about.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.BuildConfig
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentAboutBinding
 import ro.code4.deurgenta.helper.takeUserTo
-import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class AboutFragment : BaseAnalyticsFragment() {
+class AboutFragment : BaseFragment(R.layout.fragment_about) {
+
+    private val binding: FragmentAboutBinding by viewBinding(FragmentAboutBinding::bind)
+
     override val screenName: Int
         get() = R.string.analytics_title_about
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return inflater.inflate(R.layout.fragment_about, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        organization_facebook.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_FACEBOOK_URL) }
-        organization_instagram.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_INSTAGRAM_URL) }
-        organization_url.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_URL) }
-        organization_github.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_GITHUB_URL) }
-        organization_donate.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_DONATE_URL) }
+        binding.organizationFacebook.setOnClickListener {
+            requireActivity().takeUserTo(BuildConfig.CODE4RO_FACEBOOK_URL)
+        }
+        binding.organizationInstagram.setOnClickListener {
+            requireActivity().takeUserTo(BuildConfig.CODE4RO_INSTAGRAM_URL)
+        }
+        binding.organizationUrl.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_URL) }
+        binding.organizationGithub.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_GITHUB_URL) }
+        binding.organizationDonate.setOnClickListener { requireActivity().takeUserTo(BuildConfig.CODE4RO_DONATE_URL) }
     }
 
     override fun onResume() {
         super.onResume()
         requireActivity().title = getString(R.string.about_title)
     }
-
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/address/ConfigureAddressFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/address/ConfigureAddressFragment.kt
@@ -21,7 +21,6 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.gms.common.api.ResolvableApiException
 import com.here.sdk.mapview.MapView
 import com.here.sdk.search.Suggestion
-import kotlinx.android.synthetic.main.layout_mapview.*
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.MapAddressType
@@ -272,10 +271,10 @@ class ConfigureAddressFragment : PermissionsViewModelFragment<ConfigureAddressVi
     }
 
     private fun setAsLoading(isLoading: Boolean) {
-        mapLoadingIndicator?.visibility = if (isLoading) View.VISIBLE else View.GONE
+        viewBinding.mapViewLayout.mapLoadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
         if (isLoading) {
             loadingAnimator?.cancel()
-            loadingAnimator = mapLoadingIndicator.setToRotateIndefinitely()
+            loadingAnimator = viewBinding.mapViewLayout.mapLoadingIndicator.setToRotateIndefinitely()
             loadingAnimator?.start()
         }
     }

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthActivity.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthActivity.kt
@@ -1,17 +1,16 @@
 package ro.code4.deurgenta.ui.auth
 
 import android.os.Bundle
-import kotlinx.android.synthetic.main.activity_auth.*
-import kotlinx.android.synthetic.main.fragment_auth.*
-import kotlinx.android.synthetic.main.fragment_register.*
+import android.widget.Button
+import android.widget.FrameLayout
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.helper.replaceFragment
 import ro.code4.deurgenta.helper.startActivityWithoutTrace
-import ro.code4.deurgenta.ui.base.BaseAnalyticsActivity
 import ro.code4.deurgenta.ui.auth.login.LoginFormFragment
 import ro.code4.deurgenta.ui.auth.register.RegisterCompletedFragment
 import ro.code4.deurgenta.ui.auth.register.RegisterFragment
+import ro.code4.deurgenta.ui.base.BaseAnalyticsActivity
 
 class AuthActivity : BaseAnalyticsActivity<AuthViewModel>() {
 
@@ -21,10 +20,11 @@ class AuthActivity : BaseAnalyticsActivity<AuthViewModel>() {
         get() = R.string.analytics_title_login
 
     override val viewModel: AuthViewModel by viewModel()
+    private lateinit var authContainer: FrameLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        authContainer = findViewById(R.id.auth_container)
         if (savedInstanceState == null) {
             showAuthFragment()
         }
@@ -77,7 +77,7 @@ class AuthActivity : BaseAnalyticsActivity<AuthViewModel>() {
                     activity?.let(::startActivityWithoutTrace)
                 },
                 onFailure = { error ->
-                    showDefaultErrorSnackBar(auth_container)
+                    showDefaultErrorSnackBar(authContainer)
                 }
             )
         })
@@ -90,7 +90,7 @@ class AuthActivity : BaseAnalyticsActivity<AuthViewModel>() {
                     showRegistrationCompletedFragment()
                 },
                 onFailure = { error ->
-                    showDefaultErrorSnackBar(submitButton)
+                    showDefaultErrorSnackBar(authContainer)
                 }
             )
         })

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthFragment.kt
@@ -1,52 +1,23 @@
 package ro.code4.deurgenta.ui.auth
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.activity_auth.*
-import kotlinx.android.synthetic.main.fragment_auth.*
-import kotlinx.android.synthetic.main.fragment_register.*
-import org.koin.android.viewmodel.ext.android.viewModel
+import androidx.fragment.app.activityViewModels
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.R
-import ro.code4.deurgenta.helper.replaceFragment
-import ro.code4.deurgenta.helper.startActivityWithoutTrace
-import ro.code4.deurgenta.ui.base.BaseAnalyticsActivity
-import ro.code4.deurgenta.ui.auth.login.LoginFormFragment
-import ro.code4.deurgenta.ui.auth.register.RegisterCompletedFragment
-import ro.code4.deurgenta.ui.auth.register.RegisterFragment
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.databinding.FragmentAuthBinding
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class AuthFragment : ViewModelFragment<AuthViewModel>()  {
+class AuthFragment : BaseFragment(R.layout.fragment_auth) {
 
-    override val layout: Int
-        get() = R.layout.fragment_auth
     override val screenName: Int
         get() = R.string.analytics_title_login
-
-    override lateinit var viewModel: AuthViewModel;
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        viewModel = activity?.run {
-            ViewModelProvider(this)[AuthViewModel::class.java]
-        } ?: throw Exception("Invalid Activity")
-    }
+    private val viewModel: AuthViewModel by activityViewModels()
+    private val binding: FragmentAuthBinding by viewBinding(FragmentAuthBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        clickListenersSetup()
-    }
-
-
-    private fun clickListenersSetup() {
-        loginButton.setOnClickListener {
-            viewModel.onLoginClicked()
-        }
-        signupButton.setOnClickListener {
-            viewModel.onSignUpClicked()
-        }
+        binding.loginButton.setOnClickListener { viewModel.onLoginClicked() }
+        binding.signupButton.setOnClickListener { viewModel.onSignUpClicked() }
     }
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/login/LoginFormFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/login/LoginFormFragment.kt
@@ -4,33 +4,18 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_login.*
-import kotlinx.android.synthetic.main.fragment_login.view.*
-import kotlinx.android.synthetic.main.include_toolbar.toolbar
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.ext.android.inject
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentLoginBinding
 import ro.code4.deurgenta.helper.startActivityWithoutTrace
 import ro.code4.deurgenta.ui.auth.reset.ResetPasswordFragment
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class LoginFormFragment : ViewModelFragment<LoginFormViewModel>() {
+class LoginFormFragment : BaseFragment(R.layout.fragment_login) {
 
-    companion object {
-        private const val RC_SIGN_IN = 7
-    }
-
-    //private lateinit var callbackManager: CallbackManager
-    /*
-    private val appleLoginConfig = SignInWithAppleConfiguration(
-        clientId = "ro.code5.deurgenta.ui.login",
-        redirectUri = "www.deurgenta.ro/callback",
-        scope = "name email"
-    )
-    */
-
-    override val layout: Int
-        get() = R.layout.fragment_login
-    override val viewModel: LoginFormViewModel by inject()
+    private val binding: FragmentLoginBinding by viewBinding(FragmentLoginBinding::bind)
+    val viewModel: LoginFormViewModel by inject()
 
     override val screenName: Int
         get() = R.string.login_fragment_name
@@ -38,101 +23,25 @@ class LoginFormFragment : ViewModelFragment<LoginFormViewModel>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        btn_forgot_password.setOnClickListener {
+        binding.btnForgotPassword.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.auth_container, ResetPasswordFragment.newInstance())
                 .addToBackStack(null)
                 .commit()
         }
-
-        //callbackManager = CallbackManager.Factory.create()
-
-        view.login_btn.setOnClickListener {
-            login_btn.isEnabled = false
-
-            val email = username.text.toString()
-            val password = password.text.toString()
+        binding.loginBtn.setOnClickListener {
+            binding.loginBtn.isEnabled = false
+            val email = binding.username.text.toString()
+            val password = binding.password.text.toString()
             viewModel.login(email, password)
         }
-
-        /* Commenting for now as they are not included in MVP
-        view.google_login.setOnClickListener {
-            handleGoogleLoginClick()
-        }
-
-        setFacebookLoginListener()
-        view.apple_login.setOnClickListener {
-            view.sign_in_with_apple_button.performClick()
-        }
-
-        view.sign_in_with_apple_button.setUpSignInWithAppleOnClick(
-            childFragmentManager,
-            appleLoginConfig
-        ) { result ->
-            when (result) {
-                is SignInWithAppleResult.Success -> {
-                    // TODO: set auth token
-                    viewModel.onSuccessfulLogin()
-                }
-                is SignInWithAppleResult.Failure -> {
-                    // Handle failure
-                }
-                is SignInWithAppleResult.Cancel -> {
-                    // Handle user cancel
-                }
-            }
-        }
-        */
-
         loginUserObservable()
     }
 
     override fun onResume() {
         super.onResume()
-        toolbar.title = resources.getString(R.string.login_auth_title)
+        binding.includedToolbar.toolbar.title = resources.getString(R.string.login_auth_title)
     }
-
-    /* Commenting for now as they are not included in MVP
-    private fun setFacebookLoginListener() {
-        view?.facebook_login?.setOnClickListener {
-            // TODO: initiate Facebook login
-        }
-    }
-
-    private fun handleGoogleLoginClick() {
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail()
-            .build()
-
-        val googleSignInClient = GoogleSignIn.getClient(requireActivity(), gso)
-        val signInIntent = googleSignInClient.signInIntent
-        startActivityForResult(signInIntent, RC_SIGN_IN)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        callbackManager.onActivityResult(requestCode, resultCode, data)
-
-        if (requestCode == RC_SIGN_IN) {
-            // The Task returned from this call is always completed, no need to attach
-            // a listener.
-            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
-            handleGoogleSignInResult(task)
-        }
-
-        super.onActivityResult(requestCode, resultCode, data)
-    }
-
-    private fun handleGoogleSignInResult(completedTask: Task<GoogleSignInAccount>) {
-        try {
-            // TODO: use sign in result
-            val account = completedTask.getResult(ApiException::class.java)
-        } catch (e: ApiException) {
-            // The ApiException status code indicates the detailed failure reason.
-            // Please refer to the GoogleSignInStatusCodes class reference for more information.
-            Log.e("Google", " signInResult : failed code = ${e.statusCode}")
-        }
-    }
-    */
 
     private fun loginUserObservable() {
         viewModel.loggedIn().observe(viewLifecycleOwner, Observer {
@@ -142,12 +51,11 @@ class LoginFormFragment : ViewModelFragment<LoginFormViewModel>() {
                 },
                 onFailure = { error ->
                     // TODO: display some friendlier errors
-                    Snackbar.make(login_btn, "Error: ${error.message}", Snackbar.LENGTH_LONG).show()
-
-                    login_btn.isEnabled = true
+                    Snackbar.make(binding.loginBtn, "Error: ${error.message}", Snackbar.LENGTH_LONG).show()
+                    binding.loginBtn.isEnabled = true
                 },
                 onLoading = {
-                    Snackbar.make(login_btn, "Loading", Snackbar.LENGTH_INDEFINITE).show()
+                    Snackbar.make(binding.loginBtn, "Loading", Snackbar.LENGTH_INDEFINITE).show()
                 }
             )
         })

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/register/RegisterCompletedFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/register/RegisterCompletedFragment.kt
@@ -2,21 +2,21 @@ package ro.code4.deurgenta.ui.auth.register
 
 import android.os.Bundle
 import android.view.View
-import kotlinx.android.synthetic.main.fragment_completed_register.*
-import kotlinx.android.synthetic.main.include_toolbar.toolbar
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.R
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.databinding.FragmentCompletedRegisterBinding
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class RegisterCompletedFragment : ViewModelFragment<RegisterViewModel>() {
-    override val layout: Int
-        get() = R.layout.fragment_completed_register
+class RegisterCompletedFragment : BaseFragment(R.layout.fragment_completed_register) {
+
+    private val binding: FragmentCompletedRegisterBinding by viewBinding(FragmentCompletedRegisterBinding::bind)
+
     override val screenName: Int
         get() = R.string.analytics_title_register
-    override lateinit var viewModel: RegisterViewModel
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.title = resources.getString(R.string.register_completed_title)
-        to_login_screen.setOnClickListener { parentFragmentManager.popBackStack() }
+        binding.includedToolbar.toolbar.title = resources.getString(R.string.register_completed_title)
+        binding.toLoginScreen.setOnClickListener { parentFragmentManager.popBackStack() }
     }
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/register/RegisterFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/register/RegisterFragment.kt
@@ -6,11 +6,9 @@ import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.widget.Toolbar
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.fragment_register.*
 import org.koin.android.ext.android.inject
 import ro.code4.deurgenta.BuildConfig.TERMS_AND_CONDITIONS
 import ro.code4.deurgenta.R
@@ -19,14 +17,16 @@ import ro.code4.deurgenta.ui.auth.AuthViewModel
 import ro.code4.deurgenta.ui.base.ViewModelFragment
 
 class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
+
     override val layout: Int
         get() = R.layout.fragment_register
     override val screenName: Int
         get() = R.string.analytics_title_register
 
     override val viewModel: RegisterViewModel by inject()
-    lateinit var authViewModel: AuthViewModel
-    var registerRequestDisposable: Disposable? = null
+    private lateinit var authViewModel: AuthViewModel
+    private lateinit var binding: FragmentRegisterBinding
+    private var registerRequestDisposable: Disposable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,15 +41,11 @@ class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-
-        val binding: FragmentRegisterBinding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_register, container, false
-        )
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_register, container, false)
         binding.lifecycleOwner = this
         binding.viewmodel = viewModel
         @Suppress("USELESS_CAST") // cast needed
-        (binding.toolbar as Toolbar).setTitle(R.string.register_title)
+        binding.includedToolbar.toolbar.setTitle(R.string.register_title)
         return binding.root
     }
 
@@ -60,10 +56,9 @@ class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
     }
 
     private fun clickListenersSetup() {
-        submitButton.setOnClickListener {
+        binding.submitButton.setOnClickListener {
             viewModel.register()
         }
-
         termsAndConditionsSetup()
     }
 
@@ -74,12 +69,21 @@ class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
         val passwordError = viewModel.getPasswordError()
         val termsError = viewModel.getTermsError()
 
-        if (!termsError.isNullOrBlank()) termsCheckBox.error = termsError
-        if (!passwordError.isNullOrBlank()) passwordEditText.error = passwordError
-        if (!emailError.isNullOrBlank()) emailEditText.error = emailError
-        if (!lastNameError.isNullOrBlank()) lastNameEditText.error = lastNameError
-        if (!firstNameError.isNullOrBlank()) firstNameEditText.error = firstNameError
-
+        if (!termsError.isNullOrBlank()) {
+            binding.termsCheckBox.error = termsError
+        }
+        if (!passwordError.isNullOrBlank()) {
+            binding.passwordEditText.error = passwordError
+        }
+        if (!emailError.isNullOrBlank()) {
+            binding.emailEditText.error = emailError
+        }
+        if (!lastNameError.isNullOrBlank()) {
+            binding.lastNameEditText.error = lastNameError
+        }
+        if (!firstNameError.isNullOrBlank()) {
+            binding.firstNameEditText.error = firstNameError
+        }
     }
 
     private fun registerObservable() {
@@ -108,12 +112,11 @@ class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
         val termsLinkText = getString(R.string.register_terms_link_text)
         val termsLinkHtml = "<a href='$termsLink'>$termsLinkText</a>"
         val termsText = getString(R.string.register_terms_text).replace("{link}", termsLinkHtml)
-        termsTextView.text = Html.fromHtml(termsText);
-        termsTextView.isClickable = true;
-        termsTextView.movementMethod = LinkMovementMethod.getInstance();
-
-        termsCheckBox.setOnClickListener {
-            termsCheckBox.error = null
+        binding.termsTextView.text = Html.fromHtml(termsText)
+        binding.termsTextView.isClickable = true;
+        binding.termsTextView.movementMethod = LinkMovementMethod.getInstance()
+        binding.termsCheckBox.setOnClickListener {
+            binding.termsCheckBox.error = null
         }
     }
 
@@ -121,5 +124,4 @@ class RegisterFragment : ViewModelFragment<RegisterViewModel>() {
         super.onDestroyView()
         registerRequestDisposable?.dispose()
     }
-
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/reset/ResetPasswordFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/reset/ResetPasswordFragment.kt
@@ -4,48 +4,41 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
-import kotlinx.android.synthetic.main.fragment_reset_password.btn_reset_password
-import kotlinx.android.synthetic.main.fragment_reset_password.confirm_password_input
-import kotlinx.android.synthetic.main.fragment_reset_password.confirm_password_input_layout
-import kotlinx.android.synthetic.main.fragment_reset_password.email_input
-import kotlinx.android.synthetic.main.fragment_reset_password.email_input_layout
-import kotlinx.android.synthetic.main.fragment_reset_password.new_password_input
-import kotlinx.android.synthetic.main.fragment_reset_password.new_password_input_layout
-import kotlinx.android.synthetic.main.include_toolbar.toolbar
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentResetPasswordBinding
 import ro.code4.deurgenta.ui.auth.reset.FieldValidationStatus.EmailNotValid
 import ro.code4.deurgenta.ui.auth.reset.FieldValidationStatus.PasswordTooShort
 import ro.code4.deurgenta.ui.auth.reset.FieldValidationStatus.Valid
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class ResetPasswordFragment : ViewModelFragment<ResetPasswordViewModel>() {
+class ResetPasswordFragment : BaseFragment(R.layout.fragment_reset_password) {
 
     override val screenName: Int
         get() = R.string.analytics_title_reset_password
-    override val layout: Int
-        get() = R.layout.fragment_reset_password
-    override val viewModel: ResetPasswordViewModel by viewModel()
+    private val viewModel: ResetPasswordViewModel by viewModel()
+    private val binding: FragmentResetPasswordBinding by viewBinding(FragmentResetPasswordBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        email_input.doOnTextChanged { email, _, _, _ ->
+        binding.emailInput.doOnTextChanged { email, _, _, _ ->
             viewModel.validateEmail(email.toString())
         }
-        new_password_input.doOnTextChanged { password, _, _, _ ->
+        binding.newPasswordInput.doOnTextChanged { password, _, _, _ ->
             if (password != null && password.isEmpty()) {
-                new_password_input_layout.error = null
+                binding.newPasswordInputLayout.error = null
                 return@doOnTextChanged
             }
             viewModel.validatePassword(password.toString())
         }
-        confirm_password_input.doOnTextChanged { confirmedPassword, _, _, _ ->
-            val chosenPassword = new_password_input.text.toString()
+        binding.confirmPasswordInput.doOnTextChanged { confirmedPassword, _, _, _ ->
+            val chosenPassword = binding.newPasswordInput.text.toString()
             if (chosenPassword.isEmpty() || (confirmedPassword != null && confirmedPassword.isEmpty())) {
-                confirm_password_input_layout.error = null
+                binding.confirmPasswordInputLayout.error = null
                 return@doOnTextChanged
             }
-            confirm_password_input_layout.error =
+            binding.confirmPasswordInputLayout.error =
                 if (confirmedPassword != null && confirmedPassword.toString() != chosenPassword) {
                     getString(R.string.reset_password_different_passwords)
                 } else {
@@ -60,34 +53,34 @@ class ResetPasswordFragment : ViewModelFragment<ResetPasswordViewModel>() {
             ResetPasswordInfoDialogFragment().show(childFragmentManager, RESET_PASSWORD_DIALOG)
         }
         viewModel.emailValidationStatus.observe(viewLifecycleOwner) { status ->
-            email_input_layout.error = when (status) {
+            binding.emailInputLayout.error = when (status) {
                 Valid -> null
                 EmailNotValid -> getString(R.string.reset_password_invalid_email)
                 else -> throw IllegalArgumentException("Unknown validation status for field: reset email")
             }
         }
         viewModel.passwordValidationStatus.observe(viewLifecycleOwner) { status ->
-            new_password_input_layout.error = when (status) {
+            binding.newPasswordInputLayout.error = when (status) {
                 Valid -> null
                 PasswordTooShort -> getString(R.string.reset_password_password_too_short)
                 else -> throw IllegalArgumentException("Unknown validation status for field: reset password")
             }
         }
-        btn_reset_password.setOnClickListener {
-            val email = email_input.text.toString()
-            val newPassword = new_password_input.text.toString()
-            val confirmedPassword = confirm_password_input.text.toString()
+        binding.btnResetPassword.setOnClickListener {
+            val email = binding.emailInput.text.toString()
+            val newPassword = binding.newPasswordInput.text.toString()
+            val confirmedPassword = binding.confirmPasswordInput.text.toString()
             if (newPassword == confirmedPassword) {
                 viewModel.resetPassword(email, newPassword)
             } else {
-                confirm_password_input_layout.error = getString(R.string.reset_password_different_passwords)
+                binding.confirmPasswordInputLayout.error = getString(R.string.reset_password_different_passwords)
             }
         }
     }
 
     override fun onResume() {
         super.onResume()
-        toolbar.title = resources.getString(R.string.reset_password_title)
+        binding.includedToolbar.toolbar.title = resources.getString(R.string.reset_password_title)
     }
 
     companion object {

--- a/app/src/main/java/ro/code4/deurgenta/ui/backpack/items/BackpackItemsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/backpack/items/BackpackItemsFragment.kt
@@ -7,23 +7,23 @@ import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_backpack_items.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.viewModel
-import org.parceler.Parcels
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.Backpack
 import ro.code4.deurgenta.data.model.BackpackItemType
+import ro.code4.deurgenta.databinding.FragmentBackpackItemsBinding
 import ro.code4.deurgenta.helper.setToRotateIndefinitely
 import ro.code4.deurgenta.ui.backpack.edit.EditBackpackItemFragment
 import ro.code4.deurgenta.ui.backpack.edit.NewItemData
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class BackpackItemsFragment : ViewModelFragment<BackpackItemsViewModel>() {
+class BackpackItemsFragment : BaseFragment(R.layout.fragment_backpack_items) {
+
     override val screenName: Int
         get() = R.string.app_name
-    override val layout: Int
-        get() = R.layout.fragment_backpack_items
-    override val viewModel: BackpackItemsViewModel by viewModel()
+    private val viewModel: BackpackItemsViewModel by viewModel()
+    private val binding: FragmentBackpackItemsBinding by viewBinding(FragmentBackpackItemsBinding::bind)
     private lateinit var backpack: Backpack
     private lateinit var type: BackpackItemType
     private val itemsAdapter: BackpackItemsAdapter by lazy {
@@ -32,7 +32,7 @@ class BackpackItemsFragment : ViewModelFragment<BackpackItemsViewModel>() {
                 R.id.action_backpackItems_to_editBackpackItem,
                 bundleOf(
                     EditBackpackItemFragment.KEY_REQUEST_TYPE to EditBackpackItemFragment.TYPE_EDIT_ITEM,
-                    EditBackpackItemFragment.KEY_EDIT_ITEM_DATA to Parcels.wrap(it)
+                    EditBackpackItemFragment.KEY_EDIT_ITEM_DATA to it
                 )
             )
         }, { itemId -> viewModel.deleteItem(itemId) })
@@ -41,20 +41,22 @@ class BackpackItemsFragment : ViewModelFragment<BackpackItemsViewModel>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        backpack = Parcels.unwrap(arguments?.getParcelable(KEY_BACKPACK))
-        type = Parcels.unwrap(arguments?.getParcelable(KEY_ITEM_TYPE))
+        backpack = arguments?.getParcelable(KEY_BACKPACK)
+            ?: error("A backpack reference must be provided to show it items!")
+        type = arguments?.getParcelable(KEY_ITEM_TYPE)
+            ?: error("A reference to the type of backpack items must be provided!")
 
-        change_contents.setOnClickListener {
+        binding.changeContents.setOnClickListener {
             findNavController().navigate(
                 R.id.action_backpackItems_to_editBackpackItem,
                 bundleOf(
                     EditBackpackItemFragment.KEY_REQUEST_TYPE to EditBackpackItemFragment.TYPE_NEW_ITEM,
-                    EditBackpackItemFragment.KEY_NEW_ITEM_DATA to Parcels.wrap(NewItemData(backpack.id, type))
+                    EditBackpackItemFragment.KEY_NEW_ITEM_DATA to NewItemData(backpack.id, type)
                 )
             )
         }
 
-        with(backpack_items) {
+        with(binding.backpackItems) {
             layoutManager = LinearLayoutManager(requireContext())
             addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.HORIZONTAL))
             adapter = itemsAdapter
@@ -78,26 +80,26 @@ class BackpackItemsFragment : ViewModelFragment<BackpackItemsViewModel>() {
     }
 
     private fun displayLoading() {
-        loadingIndicator.visibility = View.VISIBLE
+        binding.loadingIndicator.visibility = View.VISIBLE
         loadingAnimator?.cancel()
-        loadingAnimator = loadingIndicator.setToRotateIndefinitely()
+        loadingAnimator = binding.loadingIndicator.setToRotateIndefinitely()
         loadingAnimator?.start()
-        empty.visibility = View.GONE
-        backpack_items.visibility = View.GONE
+        binding.empty.visibility = View.GONE
+        binding.backpackItems.visibility = View.GONE
     }
 
     private fun displayEmpty() {
-        loadingIndicator.visibility = View.GONE
+        binding.loadingIndicator.visibility = View.GONE
         loadingAnimator?.cancel()
-        empty.visibility = View.VISIBLE
-        backpack_items.visibility = View.GONE
+        binding.empty.visibility = View.VISIBLE
+        binding.backpackItems.visibility = View.GONE
     }
 
     private fun displayItems() {
-        loadingIndicator.visibility = View.GONE
+        binding.loadingIndicator.visibility = View.GONE
         loadingAnimator?.cancel()
-        empty.visibility = View.GONE
-        backpack_items.visibility = View.VISIBLE
+        binding.empty.visibility = View.GONE
+        binding.backpackItems.visibility = View.VISIBLE
     }
 
     override fun onResume() {

--- a/app/src/main/java/ro/code4/deurgenta/ui/backpack/main/BackpackDetailsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/backpack/main/BackpackDetailsFragment.kt
@@ -1,42 +1,37 @@
 package ro.code4.deurgenta.ui.backpack.main
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
-import kotlinx.android.synthetic.main.fragment_backpack_details.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.viewModel
-import org.parceler.Parcels
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.Backpack
 import ro.code4.deurgenta.data.model.BackpackItemType
+import ro.code4.deurgenta.databinding.FragmentBackpackDetailsBinding
 import ro.code4.deurgenta.ui.backpack.items.BackpackItemsFragment
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class BackpackDetailsFragment : ViewModelFragment<BackpackDetailsViewModel>() {
+class BackpackDetailsFragment : BaseFragment(R.layout.fragment_backpack_details) {
+
     override val screenName: Int
         get() = R.string.app_name
-    override val layout: Int
-        get() = R.layout.fragment_backpacks
-    override val viewModel: BackpackDetailsViewModel by viewModel()
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_backpack_details, container, false)
-    }
+    private val viewModel: BackpackDetailsViewModel by viewModel()
+    private val binding: FragmentBackpackDetailsBinding by viewBinding(FragmentBackpackDetailsBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val backpack: Backpack = Parcels.unwrap(arguments?.getParcelable(KEY_BACKPACK))
+        val backpack: Backpack = arguments?.getParcelable(KEY_BACKPACK)
+            ?: error("A backpack reference must be provided to show its details!")
         requireActivity().title = backpack.name
 
         buildBackpackUI(backpack)
 
-        choose_person_responsible.setOnClickListener {
+        binding.choosePersonResponsible.setOnClickListener {
             Toast.makeText(requireContext(), "Not implemented yet!", Toast.LENGTH_SHORT).show()
         }
     }
@@ -48,7 +43,8 @@ class BackpackDetailsFragment : ViewModelFragment<BackpackDetailsViewModel>() {
         BackpackItemType.values().forEachIndexed { index, type ->
             val entryView = requireActivity().layoutInflater.inflate(
                 R.layout.item_backpack_item_type,
-                backpack_content, false
+                binding.backpackContent,
+                false
             ) as TextView
             with(entryView) {
                 text = descriptions[index]
@@ -59,13 +55,13 @@ class BackpackDetailsFragment : ViewModelFragment<BackpackDetailsViewModel>() {
                 setOnClickListener {
                     findNavController().navigate(
                         R.id.action_backpackDetails_to_backpackItems, bundleOf(
-                            BackpackItemsFragment.KEY_BACKPACK to Parcels.wrap(backpack),
-                            BackpackItemsFragment.KEY_ITEM_TYPE to Parcels.wrap(type)
+                            BackpackItemsFragment.KEY_BACKPACK to backpack,
+                            BackpackItemsFragment.KEY_ITEM_TYPE to type
                         )
                     )
                 }
             }
-            backpack_content.addView(entryView)
+            binding.backpackContent.addView(entryView)
         }
         typedIcons.recycle()
     }

--- a/app/src/main/java/ro/code4/deurgenta/ui/backpack/main/BackpacksFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/backpack/main/BackpacksFragment.kt
@@ -11,48 +11,47 @@ import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_backpacks.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.sharedViewModel
-import org.parceler.Parcels
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.Backpack
+import ro.code4.deurgenta.databinding.FragmentBackpacksBinding
 import ro.code4.deurgenta.helper.logE
 import ro.code4.deurgenta.helper.setToRotateIndefinitely
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class BackpacksFragment : ViewModelFragment<BackpacksViewModel>() {
+class BackpacksFragment : BaseFragment(R.layout.fragment_backpacks) {
+
     override val screenName: Int
         get() = R.string.analytics_title_backpack
-    override val layout: Int
-        get() = R.layout.fragment_backpacks
-    override val viewModel: BackpacksViewModel by sharedViewModel(from = { requireParentFragment() })
+    private val viewModel: BackpacksViewModel by sharedViewModel(from = { requireParentFragment() })
     private val backpacksAdapter: BackpacksAdapter by lazy {
         BackpacksAdapter(requireContext()) {
             if (it !== Backpack.EMPTY) {
                 findNavController().navigate(
                     R.id.action_backpacks_to_backpackDetails,
-                    bundleOf(BackpackDetailsFragment.KEY_BACKPACK to Parcels.wrap(it))
+                    bundleOf(BackpackDetailsFragment.KEY_BACKPACK to it)
                 )
             }
         }
     }
     private var loadingAnimator: ObjectAnimator? = null
+    private val binding: FragmentBackpacksBinding by viewBinding(FragmentBackpacksBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.fetchBackpacks()
 
-        add_new_backpack.setOnClickListener {
+        binding.addNewBackpack.setOnClickListener {
             findNavController().navigate(R.id.action_backpacks_to_newBackpackDialog)
         }
-
-        with(remainder) {
+        with(binding.remainder) {
             val underlineAction = SpannableString(getString(R.string.backpack_btn_reminder))
             underlineAction.setSpan(UnderlineSpan(), 0, underlineAction.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
             text = underlineAction
             setOnClickListener { findNavController().navigate(R.id.action_backpacks_to_home) }
         }
-        with(backpacks_list) {
+        with(binding.backpacksList) {
             layoutManager = LinearLayoutManager(requireContext())
             addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
             adapter = backpacksAdapter
@@ -80,13 +79,13 @@ class BackpacksFragment : ViewModelFragment<BackpacksViewModel>() {
     }
 
     private fun setAsLoading(isLoading: Boolean) {
-        loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
+        binding.loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
         if (isLoading) {
             loadingAnimator?.cancel()
-            loadingAnimator = loadingIndicator.setToRotateIndefinitely()
+            loadingAnimator = binding.loadingIndicator.setToRotateIndefinitely()
             loadingAnimator?.start()
         }
-        backpacks_list.visibility = if (isLoading) View.GONE else View.VISIBLE
+        binding.backpacksList.visibility = if (isLoading) View.GONE else View.VISIBLE
     }
 
     override fun onResume() {

--- a/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsActivity.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsActivity.kt
@@ -1,16 +1,12 @@
 package ro.code4.deurgenta.ui.base
 
-import com.google.firebase.analytics.FirebaseAnalytics
-import org.koin.android.ext.android.inject
 import ro.code4.deurgenta.interfaces.AnalyticsScreenName
 
 abstract class BaseAnalyticsActivity<out T : BaseViewModel> : BaseActivity<T>(), AnalyticsScreenName {
 
-    private val firebaseAnalytics: FirebaseAnalytics by inject()
-
     override fun onResume() {
         super.onResume()
-
-        firebaseAnalytics.setCurrentScreen(this, getString(screenName), null)
+        // TODO find a replacement for this(also implement it in the fragment!)
+        //firebaseAnalytics.setCurrentScreen(this, getString(screenName), null)
     }
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/base/BaseAnalyticsFragment.kt
@@ -4,18 +4,16 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.koin.android.ext.android.inject
 import ro.code4.deurgenta.analytics.Event
 import ro.code4.deurgenta.analytics.Param
 import ro.code4.deurgenta.analytics.ParamKey
-import ro.code4.deurgenta.helper.logD
-import ro.code4.deurgenta.helper.logW
 import ro.code4.deurgenta.interfaces.AnalyticsScreenName
+import ro.code4.deurgenta.services.AnalyticsService
 
 abstract class BaseAnalyticsFragment : Fragment, AnalyticsScreenName {
 
-    private val firebaseAnalytics: FirebaseAnalytics by inject()
+    private val analyticsService: AnalyticsService by inject()
 
     protected constructor() : super()
 
@@ -23,28 +21,6 @@ abstract class BaseAnalyticsFragment : Fragment, AnalyticsScreenName {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        logAnalyticsEvent(
-            Event.SCREEN_OPEN,
-            Param(ParamKey.NAME, this.javaClass.simpleName))
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        firebaseAnalytics.setCurrentScreen(requireActivity(), getString(screenName), null)
-    }
-
-    fun logAnalyticsEvent(event: Event, vararg params: Param) {
-        logD("logAnalyticsEvent: ${event.name}")
-        val bundle = Bundle()
-        for ((k, v) in params ) {
-            when (v) {
-                is String -> bundle.putString(k.title, v)
-                is Int -> bundle.putInt(k.title, v)
-                else -> logW("Not implemented bundle params for ${v.javaClass}")
-            }
-        }
-        firebaseAnalytics.logEvent(event.title, bundle)
+        analyticsService.logEvent(Event.SCREEN_OPEN, Param(ParamKey.NAME, this.javaClass.simpleName))
     }
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/base/BaseFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/base/BaseFragment.kt
@@ -1,0 +1,26 @@
+package ro.code4.deurgenta.ui.base
+
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
+import org.koin.android.ext.android.inject
+import ro.code4.deurgenta.analytics.Event
+import ro.code4.deurgenta.analytics.Param
+import ro.code4.deurgenta.analytics.ParamKey
+import ro.code4.deurgenta.interfaces.AnalyticsScreenName
+import ro.code4.deurgenta.services.AnalyticsService
+
+/**
+ * The base class for all fragments in the application, with the exception(for now) of fragments that currently use
+ * data binding or require additional features(like system permissions).
+ */
+abstract class BaseFragment(@LayoutRes layoutId: Int) : Fragment(layoutId), AnalyticsScreenName {
+
+    private val analyticsService: AnalyticsService by inject()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        analyticsService.logEvent(Event.SCREEN_OPEN, Param(ParamKey.NAME, this.javaClass.simpleName))
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/courses/CourseDetailsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/courses/CourseDetailsFragment.kt
@@ -1,38 +1,31 @@
 package ro.code4.deurgenta.ui.courses
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_courses_details.*
-import org.parceler.Parcels
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.Course
+import ro.code4.deurgenta.databinding.FragmentCoursesDetailsBinding
 import ro.code4.deurgenta.helper.dateFormatter
 import ro.code4.deurgenta.helper.takeUserTo
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class CourseDetailsFragment : BaseAnalyticsFragment() {
+class CourseDetailsFragment : BaseFragment(R.layout.fragment_courses_details) {
     override val screenName: Int
         get() = R.string.analytics_title_courses_details
 
+    private val binding: FragmentCoursesDetailsBinding by viewBinding(FragmentCoursesDetailsBinding::bind)
     private lateinit var course: Course
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_courses_details, container, false)
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        course = Parcels.unwrap(arguments?.getParcelable(KEY_COURSE))
-        provider.text = course.provider
-        date.text = dateFormatter.format(course.date)
-        location.text = course.location
-        info.text = course.description
-        btn_course_register.setOnClickListener {
-            requireActivity().takeUserTo(course.url)
-        }
+        course = arguments?.getParcelable(KEY_COURSE) ?: error("Must provide a course reference to see its details!")
+        binding.provider.text = course.provider
+        binding.date.text = dateFormatter.format(course.date)
+        binding.location.text = course.location
+        binding.info.text = course.description
+        binding.btnCourseRegister.setOnClickListener { requireActivity().takeUserTo(course.url) }
     }
 
     override fun onResume() {

--- a/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesFilteringFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesFilteringFragment.kt
@@ -7,26 +7,26 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
-import kotlinx.android.synthetic.main.fragment_courses_filter.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentCoursesFilterBinding
 import ro.code4.deurgenta.helper.Status
 import ro.code4.deurgenta.helper.setToRotateIndefinitely
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class CoursesFilteringFragment : ViewModelFragment<CoursesFilterViewModel>() {
+class CoursesFilteringFragment : BaseFragment(R.layout.fragment_courses_filter) {
 
     override val screenName: Int
         get() = R.string.analytics_title_courses_filtering
-    override val layout: Int
-        get() = R.layout.fragment_courses_filter
-    override val viewModel: CoursesFilterViewModel by viewModel()
+    private val viewModel: CoursesFilterViewModel by viewModel()
+    private val binding: FragmentCoursesFilterBinding by viewBinding(FragmentCoursesFilterBinding::bind)
     private var loadingAnimator: ObjectAnimator? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        loadingIndicator.setToRotateIndefinitely().start()
+        binding.loadingIndicator.setToRotateIndefinitely().start()
         viewModel.filterOptions.observe(viewLifecycleOwner) { resource ->
             when (resource.status) {
                 Status.Loading -> showAsLoading(true)
@@ -36,17 +36,17 @@ class CoursesFilteringFragment : ViewModelFragment<CoursesFilterViewModel>() {
                 }
                 Status.Error -> {
                     showAsLoading(false)
-                    selectors.visibility = View.GONE
-                    btn_to_courses_listing.isEnabled = false
+                    binding.selectors.visibility = View.GONE
+                    binding.btnToCoursesListing.isEnabled = false
                     // TODO implement this after we decide how we manage errors
                     Toast.makeText(requireContext(), "Unable to load options for filtering!", Toast.LENGTH_SHORT).show()
                 }
             }
         }
 
-        btn_to_courses_listing.setOnClickListener {
-            val selectedType = course_type_selector.selectedItem
-            val selectedLocation = course_location_selector.selectedItem
+        binding.btnToCoursesListing.setOnClickListener {
+            val selectedType = binding.courseTypeSelector.selectedItem
+            val selectedLocation = binding.courseLocationSelector.selectedItem
             if (selectedType == null || selectedLocation == null) {
                 Toast.makeText(requireContext(), getString(R.string.courses_no_selection), Toast.LENGTH_SHORT).show()
             } else {
@@ -61,26 +61,26 @@ class CoursesFilteringFragment : ViewModelFragment<CoursesFilterViewModel>() {
     }
 
     private fun setupAdapters(filterOptions: Pair<List<String>, List<String>>) {
-        course_type_selector.adapter = ArrayAdapter(
+        binding.courseTypeSelector.adapter = ArrayAdapter(
             requireContext(), android.R.layout.simple_list_item_1, filterOptions.first
         )
-        course_location_selector.adapter = ArrayAdapter(
+        binding.courseLocationSelector.adapter = ArrayAdapter(
             requireContext(), android.R.layout.simple_list_item_1, filterOptions.second
         )
     }
 
     private fun showAsLoading(isLoading: Boolean) {
-        loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
+        binding.loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
         if (isLoading) {
             loadingAnimator?.cancel()
-            loadingAnimator = loadingIndicator.setToRotateIndefinitely()
+            loadingAnimator = binding.loadingIndicator.setToRotateIndefinitely()
             loadingAnimator?.start()
         } else {
             loadingAnimator?.end()
             loadingAnimator = null
         }
-        selectors.visibility = if (isLoading) View.GONE else View.VISIBLE
-        btn_to_courses_listing.isEnabled = !isLoading
+        binding.selectors.visibility = if (isLoading) View.GONE else View.VISIBLE
+        binding.btnToCoursesListing.isEnabled = !isLoading
     }
 
     override fun onResume() {

--- a/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesInfoFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesInfoFragment.kt
@@ -1,24 +1,22 @@
 package ro.code4.deurgenta.ui.courses
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Button
 import androidx.navigation.fragment.findNavController
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class CoursesInfoFragment : BaseAnalyticsFragment() {
+class CoursesInfoFragment : BaseFragment(R.layout.fragment_courses_info) {
+
     override val screenName: Int
         get() = R.string.analytics_title_courses_info
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_courses_info, container, false).also {
-            it.findViewById<Button>(R.id.btn_to_course_filtering).setOnClickListener {
-                findNavController().navigate(R.id.action_coursesInfo_to_coursesFiltering)
-            }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Button>(R.id.btn_to_course_filtering).setOnClickListener {
+            findNavController().navigate(R.id.action_coursesInfo_to_coursesFiltering)
         }
     }
 

--- a/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesListingFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/courses/CoursesListingFragment.kt
@@ -7,29 +7,28 @@ import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_courses_listing.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import org.koin.android.viewmodel.ext.android.viewModel
-import org.parceler.Parcels
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentCoursesListingBinding
 import ro.code4.deurgenta.helper.Status
 import ro.code4.deurgenta.helper.setToRotateIndefinitely
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.ViewModelFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 import java.io.IOException
 
-class CoursesListingFragment : ViewModelFragment<CoursesViewModel>() {
+class CoursesListingFragment : BaseFragment(R.layout.fragment_courses_listing) {
 
     override val screenName: Int
         get() = R.string.analytics_title_courses_listing
-    override val layout: Int
-        get() = R.layout.fragment_courses_listing
-    override val viewModel: CoursesViewModel by viewModel()
+    private val viewModel: CoursesViewModel by viewModel()
+    private val binding: FragmentCoursesListingBinding by viewBinding(FragmentCoursesListingBinding::bind)
     private var loadingAnimator: ObjectAnimator? = null
     private val coursesAdapter: CoursesAdapter by lazy {
         CoursesAdapter(requireContext()) {
             findNavController().navigate(
                 R.id.action_coursesListing_to_courseDetails,
-                bundleOf(CourseDetailsFragment.KEY_COURSE to Parcels.wrap(it))
+                bundleOf(CourseDetailsFragment.KEY_COURSE to it)
             )
         }
     }
@@ -39,7 +38,7 @@ class CoursesListingFragment : ViewModelFragment<CoursesViewModel>() {
         val type = arguments?.getString(KEY_TYPE) ?: error("Must set a type to filter courses!")
         val location = arguments?.getString(KEY_CITY) ?: error("Must set a city to filter courses!")
         viewModel.filter(type, location)
-        with(courses) {
+        with(binding.courses) {
             layoutManager = LinearLayoutManager(requireContext())
             addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
             adapter = coursesAdapter
@@ -72,23 +71,23 @@ class CoursesListingFragment : ViewModelFragment<CoursesViewModel>() {
     }
 
     private fun showAsLoading(isLoading: Boolean) {
-        loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
+        binding.loadingIndicator.visibility = if (isLoading) View.VISIBLE else View.GONE
         if (isLoading) {
             loadingAnimator?.cancel()
-            loadingAnimator = loadingIndicator.setToRotateIndefinitely()
+            loadingAnimator = binding.loadingIndicator.setToRotateIndefinitely()
             loadingAnimator?.start()
         } else {
             loadingAnimator?.end()
             loadingAnimator = null
         }
-        courses_info_label.visibility = View.GONE
-        courses.visibility = if (isLoading) View.GONE else View.VISIBLE
+        binding.coursesInfoLabel.visibility = View.GONE
+        binding.courses.visibility = if (isLoading) View.GONE else View.VISIBLE
     }
 
     private fun showInfoDisplay(msg: String) {
-        courses_info_label.visibility = View.VISIBLE
-        courses_info_label.text = msg
-        courses.visibility = View.GONE
+        binding.coursesInfoLabel.visibility = View.VISIBLE
+        binding.coursesInfoLabel.text = msg
+        binding.courses.visibility = View.GONE
     }
 
     override fun onResume() {

--- a/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateInfoFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateInfoFragment.kt
@@ -3,25 +3,28 @@ package ro.code4.deurgenta.ui.group
 import android.os.Bundle
 import android.view.View
 import androidx.core.widget.addTextChangedListener
-import kotlinx.android.synthetic.main.fragment_group_create_info.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentGroupCreateInfoBinding
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class GroupCreateInfoFragment : BaseAnalyticsFragment(R.layout.fragment_group_create_info) {
-    override val screenName: Int = R.string.analytics_title_group
+class GroupCreateInfoFragment : BaseFragment(R.layout.fragment_group_create_info) {
+
+    override val screenName: Int
+        get() = R.string.analytics_title_group
+    private val binding: FragmentGroupCreateInfoBinding by viewBinding(FragmentGroupCreateInfoBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        input_group_name.addTextChangedListener {
+        binding.inputGroupName.addTextChangedListener {
             // Allow submission only if name is not blank
-            button_create_new_group_continue.isEnabled = !it.isNullOrEmpty()
+            binding.buttonCreateNewGroupContinue.isEnabled = !it.isNullOrEmpty()
         }
 
-        button_create_new_group_continue.setOnClickListener {
-            val name = input_group_name.text.toString()
-
+        binding.buttonCreateNewGroupContinue.setOnClickListener {
+            val name = binding.inputGroupName.text.toString()
             // TODO: create new group with the given name
         }
     }

--- a/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateLandingFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/group/GroupCreateLandingFragment.kt
@@ -2,31 +2,27 @@ package ro.code4.deurgenta.ui.group
 
 import android.graphics.Paint
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
-import kotlinx.android.synthetic.main.fragment_group_create_landing.*
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentGroupCreateLandingBinding
 import ro.code4.deurgenta.helper.updateActivityTitle
-import ro.code4.deurgenta.ui.base.BaseAnalyticsFragment
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class GroupCreateLandingFragment : BaseAnalyticsFragment() {
-    override val screenName: Int = R.string.analytics_title_group
+class GroupCreateLandingFragment : BaseFragment(R.layout.fragment_group_create_landing) {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_group_create_landing, container, false)
-    }
+    override val screenName: Int
+        get() = R.string.analytics_title_group
+    private val binding: FragmentGroupCreateLandingBinding by viewBinding(FragmentGroupCreateLandingBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        button_reject_new_group.paintFlags = button_reject_new_group.paintFlags or Paint.UNDERLINE_TEXT_FLAG
-        button_reject_new_group.setOnClickListener {
-            findNavController().navigateUp()
-        }
+        binding.buttonRejectNewGroup.paintFlags = binding.buttonRejectNewGroup.paintFlags or Paint.UNDERLINE_TEXT_FLAG
+        binding.buttonRejectNewGroup.setOnClickListener { findNavController().navigateUp() }
 
-        button_create_new_group.setOnClickListener {
+        binding.buttonCreateNewGroup.setOnClickListener {
             findNavController().navigate(R.id.action_groupLanding_to_groupCreateInfo)
         }
     }

--- a/app/src/main/java/ro/code4/deurgenta/ui/main/MainActivity.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/main/MainActivity.kt
@@ -1,9 +1,9 @@
 package ro.code4.deurgenta.ui.main
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
+import android.widget.LinearLayout
 import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Observer
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
@@ -12,15 +12,12 @@ import androidx.navigation.ui.NavigationUI.onNavDestinationSelected
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.navigation.NavigationView
 import com.google.firebase.analytics.FirebaseAnalytics
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.app_bar_main.*
-import kotlinx.android.synthetic.main.nav_footer_main.*
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.BuildConfig
 import ro.code4.deurgenta.R
-import ro.code4.deurgenta.helper.deleteToken
 import ro.code4.deurgenta.helper.startActivityWithoutTrace
 import ro.code4.deurgenta.helper.takeUserTo
 import ro.code4.deurgenta.ui.auth.AuthActivity
@@ -34,11 +31,14 @@ class MainActivity : BaseActivity<MainViewModel>() {
     override val viewModel: MainViewModel by viewModel()
     private lateinit var navController: NavController
     private lateinit var appBarConfiguration: AppBarConfiguration
+    private lateinit var drawerLayout: DrawerLayout
+    private lateinit var navView: NavigationView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setSupportActionBar(toolbar)
-
+        setSupportActionBar(findViewById(R.id.toolbar))
+        drawerLayout = findViewById(R.id.drawerLayout)
+        navView = findViewById(R.id.navView)
         navController = findNavController(R.id.nav_host_fragment)
 
         // Passing each menu ID as a set of Ids because each
@@ -74,7 +74,7 @@ class MainActivity : BaseActivity<MainViewModel>() {
             }
         }
 
-        nav_footer_donate_button.setOnClickListener {
+        findViewById<LinearLayout>(R.id.nav_footer).setOnClickListener {
             takeUserTo(BuildConfig.CODE4RO_DONATE_URL)
         }
 

--- a/app/src/main/java/ro/code4/deurgenta/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/settings/SettingsFragment.kt
@@ -3,50 +3,28 @@ package ro.code4.deurgenta.ui.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.widget.Toast
-import kotlinx.android.synthetic.main.fragment_about.*
-import kotlinx.android.synthetic.main.fragment_settings.*
-import retrofit2.http.HTTP
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import ro.code4.deurgenta.BuildConfig
 import ro.code4.deurgenta.R
+import ro.code4.deurgenta.databinding.FragmentSettingsBinding
+import ro.code4.deurgenta.ui.base.BaseFragment
 
-class SettingsFragment : Fragment() {
+class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
+
+    override val screenName: Int
+        get() = R.string.analytics_title_settings
+    private val binding: FragmentSettingsBinding by viewBinding(FragmentSettingsBinding::bind)
 
     private val contactEmailUri by lazy {
-        Uri.fromParts(    "mailto",
-            BuildConfig.SUPPORT_EMAIL,
-            null)
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_settings, container, false)
+        Uri.fromParts("mailto", BuildConfig.SUPPORT_EMAIL, null)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        report_problem.setOnClickListener {reportProblemClicked(it)}
+        binding.reportProblem.setOnClickListener {
+            val emailIntent = Intent(Intent.ACTION_SENDTO, contactEmailUri)
+            startActivity(Intent.createChooser(emailIntent, getString(R.string.report_problem)))
+        }
     }
-
-    private fun reportProblemClicked(view: View?) {
-        val emailIntent = Intent(
-                Intent.ACTION_SENDTO,
-                contactEmailUri
-        )
-        startActivity(
-                Intent.createChooser(
-                        emailIntent,
-                        getString(R.string.report_problem)
-                )
-        )
-
-    }
-
 }

--- a/app/src/main/java/ro/code4/deurgenta/ui/splashscreen/SplashScreenActivity.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/splashscreen/SplashScreenActivity.kt
@@ -2,13 +2,13 @@ package ro.code4.deurgenta.ui.splashscreen
 
 import android.os.Bundle
 import android.view.View
-import kotlinx.android.synthetic.main.activity_splash_screen.*
+import android.widget.ImageView
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.helper.setToRotateIndefinitely
 import ro.code4.deurgenta.helper.startActivityWithoutTrace
-import ro.code4.deurgenta.ui.base.BaseAnalyticsActivity
 import ro.code4.deurgenta.ui.auth.AuthActivity
+import ro.code4.deurgenta.ui.base.BaseAnalyticsActivity
 import ro.code4.deurgenta.ui.main.MainActivity
 import ro.code4.deurgenta.ui.onboarding.OnboardingActivity
 
@@ -26,7 +26,7 @@ class SplashScreenActivity : BaseAnalyticsActivity<SplashScreenViewModel>() {
         window.decorView.apply {
             systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
         }
-        logo.setToRotateIndefinitely().start()
+        findViewById<ImageView>(R.id.logo).setToRotateIndefinitely().start()
         viewModel.loginStatus.observe(this) { loginStatus ->
             val activity = when {
                 loginStatus.isUserLoggedIn && loginStatus.onboardCompleted -> MainActivity::class.java

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,21 +15,23 @@
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/navView"
+        style="@style/NavigationView"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:layout_marginTop="@dimen/margin"
-        style="@style/NavigationView"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/main_menu">
 
 
-        <include layout="@layout/nav_footer_main"
+        <include
+            android:id="@+id/nav_footer"
+            layout="@layout/nav_footer_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:gravity="center"/>
+            android:gravity="center" />
     </com.google.android.material.navigation.NavigationView>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/fragment_completed_register.xml
+++ b/app/src/main/res/layout/fragment_completed_register.xml
@@ -10,7 +10,7 @@
     tools:context="ro.code4.deurgenta.ui.auth.AuthActivity">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/includedToolbar"
         layout="@layout/include_toolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -38,9 +38,9 @@
         android:text="@string/register_completed_message"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/gray_800"
-        app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toBottomOf="@id/includedToolbar" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/to_login_screen"

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -6,7 +6,7 @@
     android:background="@color/white">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/includedToolbar"
         layout="@layout/include_toolbar"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -17,7 +17,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar">
+        app:layout_constraintTop_toBottomOf="@id/includedToolbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -118,81 +118,6 @@
                 android:textAllCaps="false"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/btn_forgot_password" />
-
-            <!-- Commenting for now as they are not included in MVP
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="#D1D5DB"
-                app:layout_constraintBottom_toBottomOf="@id/label_alternative"
-                app:layout_constraintTop_toTopOf="@id/label_alternative" />
-
-            <TextView
-                android:id="@+id/label_alternative"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/big_margin"
-                android:background="@color/white"
-                android:paddingStart="@dimen/small_margin"
-                android:paddingEnd="@dimen/small_margin"
-                android:text="@string/login_divider_text"
-                android:textColor="#6B7280"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/login_btn" />
-
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/apple_login"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/big_margin"
-                android:text="@string/login_button_apple"
-                android:textAllCaps="false"
-                app:backgroundTint="@color/design_default_color_on_secondary"
-                app:icon="@drawable/ic_apple"
-                app:iconGravity="textStart"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/label_alternative" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/google_login"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin"
-                android:text="@string/login_button_google"
-                android:textAllCaps="false"
-                app:backgroundTint="#4386F5"
-                app:icon="@drawable/ic_google"
-                app:iconGravity="textStart"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/apple_login" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/facebook_login"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin"
-                android:text="@string/login_button_facebook"
-                android:textAllCaps="false"
-                app:backgroundTint="@color/com_facebook_button_background_color_pressed"
-                app:icon="@drawable/ic_facebook"
-                app:iconGravity="textStart"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/google_login" />
-
-            <com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton
-                android:id="@+id/sign_in_with_apple_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/facebook_login" />
-
-             -->
-
         </androidx.constraintlayout.widget.ConstraintLayout>
-
     </ScrollView>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -18,7 +18,7 @@
         android:layout_height="match_parent">
 
         <include
-            android:id="@+id/toolbar"
+            android:id="@+id/includedToolbar"
             layout="@layout/include_toolbar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
-            app:layout_constraintTop_toBottomOf="@id/toolbar">
+            app:layout_constraintTop_toBottomOf="@id/includedToolbar">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_reset_password.xml
+++ b/app/src/main/res/layout/fragment_reset_password.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/includedToolbar"
         layout="@layout/include_toolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -22,7 +22,7 @@
         app:layout_constraintBottom_toTopOf="@id/btn_reset_password"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintTop_toBottomOf="@id/includedToolbar"
         app:layout_constraintVertical_bias="0"
         app:layout_constraintVertical_chainStyle="spread_inside">
 

--- a/app/src/main/res/values/analytics_strings.xml
+++ b/app/src/main/res/values/analytics_strings.xml
@@ -5,6 +5,7 @@
     <string name="analytics_title_reset_password" translatable="false">Reset password</string>
     <string name="analytics_title_login" translatable="false">Login</string>
     <string name="analytics_title_home" translatable="false">Home</string>
+    <string name="analytics_title_settings" translatable="false">Settings</string>
     <string name="analytics_title_backpack" translatable="false">Your emergency backpack</string>
     <string name="analytics_title_group" translatable="false">Group</string>
     <string name="analytics_title_about" translatable="false">About</string>

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,15 @@
 buildscript {
 
     ext {
-        kotlinVersion = "1.5.21"
+        kotlinVersion = "1.5.30"
         retrofitVersion = "2.9.0"
         koinVersion = "2.0.1"
         roomVersion = "2.3.0"
         navigationVersion = "2.4.0-alpha07"
+        firebaseVersion = "28.3.1"
+        viewBindingDelegateVersion = "1.0.0"
         adapterDelegatesVersion = "4.2.0"
         glideVersion = "4.9.0"
-        firebaseVersion = "28.3.1"
     }
 
     repositories {
@@ -18,10 +19,10 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath "com.android.tools.build:gradle:7.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+        classpath "com.google.gms:google-services:4.3.10"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:2.7.1"
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,18 +2,14 @@
 buildscript {
 
     ext {
-        kotlinVersion = '1.5.21'
-        retrofitVersion = '2.9.0'
-        koinVersion = '2.0.1'
-        parcelerVersion = '1.1.13'
-        roomVersion = '2.3.0'
-        navigationVersion = '2.4.0-alpha07'
-        firebaseAnalyticsVersion = '19.0.0'
-        firebaseCrashlyticsVersion = '18.2.1'
-        firebaseMessagingVersion = '20.2.0'
-        firebaseConfigVersion = '19.1.4'
-        adapterDelegatesVersion = '4.2.0'
-        glideVersion = '4.9.0'
+        kotlinVersion = "1.5.21"
+        retrofitVersion = "2.9.0"
+        koinVersion = "2.0.1"
+        roomVersion = "2.3.0"
+        navigationVersion = "2.4.0-alpha07"
+        adapterDelegatesVersion = "4.2.0"
+        glideVersion = "4.9.0"
+        firebaseVersion = "28.3.1"
     }
 
     repositories {


### PR DESCRIPTION
Closes #68 

In this PR:
- replaces the deprecated synthetic view access with viewbinding(excluding current usage of databinding)
- replaces the old Parcelize usage with the newer Parcelize from kotlinx.parcelize
- introduces an abstraction over FirebaseAnalytics to make the fragments easier to test, I also updated the firebase dependencies to use the recommended _bom_ declaration.


Closes #XXX 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

Manually, and the small test suite in the project passes.
