### PR TITLE
Fix auth backstack

### DIFF
--- a/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthActivity.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/auth/AuthActivity.kt
@@ -38,7 +38,7 @@ class AuthActivity : BaseAnalyticsActivity<AuthViewModel>() {
             R.id.auth_container,
             AuthFragment(),
             isPrimaryNavigationFragment = true,
-            tag = "authFragment"
+            tag = null
         )
     }
 


### PR DESCRIPTION
In the start screen when the user chooses between registering and login in, if he presses back, he will see a blank screen. This PR fixes this bug by not adding the fragment to the back stack.
