### PR TITLE
Implement address type picker

### DIFF
--- a/app/schemas/ro.code4.deurgenta.data.AppDatabase/2.json
+++ b/app/schemas/ro.code4.deurgenta.data.AppDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "047fc1f23c273ad58e368129b8723e11",
+    "identityHash": "46cc22afbc920ab51ecd665014b31d86",
     "entities": [
       {
         "tableName": "backpacks",
@@ -262,12 +262,38 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "locationTypes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '047fc1f23c273ad58e368129b8723e11')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '46cc22afbc920ab51ecd665014b31d86')"
     ]
   }
 }

--- a/app/src/androidTest/java/ro/code4/deurgenta/ui/auth/login/ResetPasswordFragmentTest.kt
+++ b/app/src/androidTest/java/ro/code4/deurgenta/ui/auth/login/ResetPasswordFragmentTest.kt
@@ -19,8 +19,8 @@ import com.google.android.material.textfield.TextInputLayout
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.reactivex.Completable
-import io.reactivex.subjects.CompletableSubject
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.subjects.CompletableSubject
 import java.io.IOException
 import org.hamcrest.Description
 import org.hamcrest.Matcher

--- a/app/src/main/java/ro/code4/deurgenta/data/AppDatabase.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/AppDatabase.kt
@@ -9,17 +9,19 @@ import ro.code4.deurgenta.data.dao.AddressDao
 import ro.code4.deurgenta.data.dao.BackpackDao
 import ro.code4.deurgenta.data.dao.CoursesDao
 import ro.code4.deurgenta.data.dao.GroupDao
+import ro.code4.deurgenta.data.dao.UserDao
 import ro.code4.deurgenta.data.helper.DateConverter
 import ro.code4.deurgenta.data.model.Backpack
 import ro.code4.deurgenta.data.model.BackpackItem
 import ro.code4.deurgenta.data.model.BackpackItemConverters
 import ro.code4.deurgenta.data.model.Course
 import ro.code4.deurgenta.data.model.Group
+import ro.code4.deurgenta.data.model.LocationType
 import ro.code4.deurgenta.data.model.MapAddress
 
 @Database(
     entities = [
-        Backpack::class, BackpackItem::class, Course::class, MapAddress::class, Group::class
+        Backpack::class, BackpackItem::class, Course::class, MapAddress::class, Group::class, LocationType::class
     ],
     version = 2
 )
@@ -29,6 +31,9 @@ import ro.code4.deurgenta.data.model.MapAddress
     MapAddress.MapAddressConverters::class
 )
 abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun userDao(): UserDao
+
     abstract fun addressDao(): AddressDao
 
     abstract fun backpackDao(): BackpackDao
@@ -50,9 +55,7 @@ abstract class AppDatabase : RoomDatabase() {
                             context.applicationContext,
                             AppDatabase::class.java,
                             "database"
-                        )
-                            //.addMigrations(*Migrations.ALL)
-                            .build()
+                        ).build() // .addMigrations(*Migrations.ALL)
                     }
                 }
             }

--- a/app/src/main/java/ro/code4/deurgenta/data/dao/UserDao.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/dao/UserDao.kt
@@ -1,0 +1,28 @@
+package ro.code4.deurgenta.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.Query
+import androidx.room.Transaction
+import io.reactivex.rxjava3.core.Observable
+import ro.code4.deurgenta.data.model.LocationType
+
+@Dao
+interface UserDao {
+
+    @Query("SELECT * FROM locationTypes")
+    fun getLocationTypes(): Observable<List<LocationType>>
+
+    @Query("DELETE FROM locationTypes")
+    fun clearLocationTypes()
+
+    @Insert(onConflict = REPLACE)
+    fun saveLocationTypes(locationTypes: List<LocationType>)
+
+    @Transaction
+    fun updateLocationTypes(newLocations: List<LocationType>) {
+        clearLocationTypes()
+        saveLocationTypes(newLocations)
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/data/model/LocationType.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/LocationType.kt
@@ -1,0 +1,18 @@
+package ro.code4.deurgenta.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "locationTypes")
+data class LocationType(
+    @PrimaryKey @ColumnInfo(name = COLUMN_ID) val id: Int,
+    @ColumnInfo(name = COLUMN_LABEL) val label: String,
+) {
+    companion object {
+        const val COLUMN_ID = "id"
+        const val COLUMN_LABEL = "name"
+    }
+
+    override fun toString(): String = label
+}

--- a/app/src/main/java/ro/code4/deurgenta/data/model/response/LocationTypeResponse.kt
+++ b/app/src/main/java/ro/code4/deurgenta/data/model/response/LocationTypeResponse.kt
@@ -1,0 +1,11 @@
+package ro.code4.deurgenta.data.model.response
+
+import com.google.gson.annotations.Expose
+import ro.code4.deurgenta.data.model.LocationType
+
+data class LocationTypeResponse(
+    @Expose val id: Int,
+    @Expose val label: String
+)
+
+fun LocationTypeResponse.toModel(): LocationType = LocationType(this.id, this.label)

--- a/app/src/main/java/ro/code4/deurgenta/di/DIModules.kt
+++ b/app/src/main/java/ro/code4/deurgenta/di/DIModules.kt
@@ -27,8 +27,11 @@ import ro.code4.deurgenta.repositories.AccountRepository
 import ro.code4.deurgenta.repositories.AccountRepositoryImpl
 import ro.code4.deurgenta.repositories.GroupRepository
 import ro.code4.deurgenta.repositories.Repository
+import ro.code4.deurgenta.repositories.UserRepository
 import ro.code4.deurgenta.services.AccountService
 import ro.code4.deurgenta.services.GroupService
+import ro.code4.deurgenta.services.UserService
+import ro.code4.deurgenta.ui.address.AddressTypeViewModel
 import ro.code4.deurgenta.ui.address.ConfigureAddressViewModel
 import ro.code4.deurgenta.ui.address.SaveAddressViewModel
 import ro.code4.deurgenta.ui.auth.AuthViewModel
@@ -96,12 +99,12 @@ val apiModule = module {
             .client(get())
             .build()
     }
-    single<AccountService> { get<Retrofit>().create(AccountService::class.java) }
+    single<AccountService> { get<Retrofit>().create() }
     single<GroupService> { get<Retrofit>().create() }
-    single {
-        Repository()
-    }
+    single<UserService> { get<Retrofit>().create() }
+    single { Repository() }
     single<AccountRepository> { AccountRepositoryImpl(get()) }
+    single { UserRepository(get<AppDatabase>().userDao(), get()) }
     single { GroupRepository(get(), get<AppDatabase>().groupDao()) }
     single<SchedulersProvider> { SchedulersProviderImpl() }
 }
@@ -125,6 +128,7 @@ val viewModelsModule = module {
     viewModel { EditBackpackItemViewModel(get()) }
     viewModel { ConfigureAddressViewModel(get()) }
     viewModel { SaveAddressViewModel(get()) }
+    viewModel { AddressTypeViewModel(get(), get()) }
     viewModel { HomeViewModel() }
     viewModel { CoursesFilterViewModel(get()) }
     viewModel { CoursesViewModel(get()) }

--- a/app/src/main/java/ro/code4/deurgenta/helper/Either.kt
+++ b/app/src/main/java/ro/code4/deurgenta/helper/Either.kt
@@ -1,0 +1,10 @@
+package ro.code4.deurgenta.helper
+
+/**
+ * Simple class to represent the result of an operation. [Right] represents a successful operation while [Left]
+ * represents and error.
+ */
+sealed class Either<out L, out R> {
+    data class Left<L>(val data: L) : Either<L, Nothing>()
+    data class Right<R>(val data: R) : Either<Nothing, R>()
+}

--- a/app/src/main/java/ro/code4/deurgenta/repositories/UserRepository.kt
+++ b/app/src/main/java/ro/code4/deurgenta/repositories/UserRepository.kt
@@ -1,0 +1,39 @@
+package ro.code4.deurgenta.repositories
+
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import ro.code4.deurgenta.data.dao.UserDao
+import ro.code4.deurgenta.data.model.LocationType
+import ro.code4.deurgenta.data.model.response.toModel
+import ro.code4.deurgenta.services.UserService
+
+class UserRepository(
+    private val userDao: UserDao,
+    private val userService: UserService,
+) {
+
+    fun refreshAndFetchLocationTypes(): Observable<List<LocationType>> {
+        val updateTask = userService.fetchLocationTypes()
+            .map { apiTypes ->
+                val mappedTypes = apiTypes.map { it.toModel() }
+                if (mappedTypes.isNotEmpty()) {
+                    userDao.updateLocationTypes(mappedTypes)
+                }
+                mappedTypes
+            }
+            .onErrorResumeWith(Single.just(emptyList()))
+        return userDao.getLocationTypes().startWith(updateTask)
+    }
+
+    fun refreshLocationTypes(): Observable<Boolean> {
+        return userService.fetchLocationTypes()
+            .map { apiTypes ->
+                if (apiTypes.isNotEmpty()) {
+                    userDao.updateLocationTypes(apiTypes.map { it.toModel() })
+                    true
+                } else {
+                    false
+                }
+            }.toObservable()
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/services/UserService.kt
+++ b/app/src/main/java/ro/code4/deurgenta/services/UserService.kt
@@ -1,0 +1,11 @@
+package ro.code4.deurgenta.services
+
+import io.reactivex.rxjava3.core.Single
+import retrofit2.http.GET
+import ro.code4.deurgenta.data.model.response.LocationTypeResponse
+
+interface UserService {
+
+    @GET("/user/location-types")
+    fun fetchLocationTypes(): Single<List<LocationTypeResponse>>
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/address/AddressTypeFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/address/AddressTypeFragment.kt
@@ -1,0 +1,80 @@
+package ro.code4.deurgenta.ui.address
+
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.navigation.Navigation.setViewNavController
+import androidx.navigation.fragment.findNavController
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import ro.code4.deurgenta.R
+import ro.code4.deurgenta.data.model.LocationType
+import ro.code4.deurgenta.databinding.FragmentAddressTypeBinding
+import ro.code4.deurgenta.helper.Either
+import ro.code4.deurgenta.ui.base.BaseFragment
+
+class AddressTypeFragment : BaseFragment(R.layout.fragment_address_type) {
+    override val screenName: Int
+        get() = R.string.analytics_title_address_type
+    private val binding: FragmentAddressTypeBinding by viewBinding(FragmentAddressTypeBinding::bind)
+    private val viewModel: AddressTypeViewModel by viewModel()
+    private val locationTypeAdapter by lazy {
+        ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_item,
+            mutableListOf<LocationType>()
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setViewNavController(binding.includedToolbar.toolbar, findNavController())
+        binding.locationTypeSelector.apply {
+            // 48 dp minimum height in layout,so the drop down sits right at the bottom of the spinner
+            dropDownVerticalOffset = resources.getDimension(R.dimen.minimum_touch_size).toInt()
+            adapter = locationTypeAdapter
+            onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    val selectedLocation = parent?.adapter?.getItem(position) as? LocationType
+                    binding.btnStartAddressSetup.isEnabled = selectedLocation != null
+                }
+
+                override fun onNothingSelected(parent: AdapterView<*>?) {
+                    binding.btnStartAddressSetup.isEnabled = false
+                }
+            }
+        }
+        binding.btnRetry.setOnClickListener {
+            binding.loadingIndicator.visibility = View.VISIBLE
+            binding.retryGroup.visibility = View.GONE
+            viewModel.refreshLocationTypes()
+        }
+        binding.btnStartAddressSetup.setOnClickListener {
+            val selectedLocationPosition = binding.locationTypeSelector.selectedItemPosition
+            if (selectedLocationPosition != AdapterView.INVALID_POSITION) {
+                // TODO pass the selected location type and pass it to the next fragment to start the map location
+                //  selection
+            }
+        }
+        viewModel.locationTypes.observe(viewLifecycleOwner) { response ->
+            binding.loadingIndicator.visibility = View.GONE
+            when (response) {
+                is Either.Right -> {
+                    if (response.data.isNotEmpty()) {
+                        setupLocationSelector(response.data)
+                        binding.retryGroup.visibility = View.GONE
+                    } else {
+                        binding.retryGroup.visibility = View.VISIBLE
+                    }
+                }
+                is Either.Left -> binding.retryGroup.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun setupLocationSelector(data: List<LocationType>) {
+        locationTypeAdapter.clear()
+        locationTypeAdapter.addAll(data)
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/address/AddressTypeViewModel.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/address/AddressTypeViewModel.kt
@@ -1,0 +1,40 @@
+package ro.code4.deurgenta.ui.address
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import ro.code4.deurgenta.data.model.LocationType
+import ro.code4.deurgenta.helper.Either
+import ro.code4.deurgenta.helper.SchedulersProvider
+import ro.code4.deurgenta.helper.plusAssign
+import ro.code4.deurgenta.repositories.UserRepository
+import ro.code4.deurgenta.ui.base.BaseViewModel
+
+class AddressTypeViewModel(
+    private val userRepository: UserRepository,
+    private val schedulersProvider: SchedulersProvider
+) : BaseViewModel() {
+
+    private val _locationTypes = MutableLiveData<Either<Throwable, List<LocationType>>>()
+    val locationTypes: LiveData<Either<Throwable, List<LocationType>>> = _locationTypes
+
+    init {
+        disposables += userRepository.refreshAndFetchLocationTypes()
+            .subscribeOn(schedulersProvider.io())
+            .map { it.sortedBy { locationType -> locationType.id } }
+            .observeOn(schedulersProvider.main())
+            .subscribe(
+                { _locationTypes.value = Either.Right(it) },
+                { _locationTypes.value = Either.Left(it) }
+            )
+    }
+
+    fun refreshLocationTypes() {
+        disposables += userRepository.refreshLocationTypes()
+            .subscribeOn(schedulersProvider.io())
+            .observeOn(schedulersProvider.main())
+            .subscribe(
+                { /* ignored as we updated the database which will refresh the UI */ },
+                { _locationTypes.value = Either.Left(it) }
+            )
+    }
+}

--- a/app/src/main/java/ro/code4/deurgenta/ui/address/SaveAddressFragment.kt
+++ b/app/src/main/java/ro/code4/deurgenta/ui/address/SaveAddressFragment.kt
@@ -10,6 +10,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import ro.code4.deurgenta.R
 import ro.code4.deurgenta.data.model.MapAddress
 import ro.code4.deurgenta.databinding.FragmentSaveAddressBinding
+import ro.code4.deurgenta.interfaces.ClickButtonCallback
 import ro.code4.deurgenta.ui.base.ViewModelFragment
 
 class SaveAddressFragment : ViewModelFragment<SaveAddressViewModel>() {
@@ -55,6 +56,9 @@ class SaveAddressFragment : ViewModelFragment<SaveAddressViewModel>() {
             viewLifecycleOwner,
             onBackPressedCallback()
         )
+        viewBinding.addNewAddressCallback = ClickButtonCallback {
+            findNavController().navigate(SaveAddressFragmentDirections.actionNavigateSaveAddressToAddressTypeFragment())
+        }
     }
 
     override fun handleOnBackPressedInternal() {

--- a/app/src/main/res/drawable/outline_spinner.xml
+++ b/app/src/main/res/drawable/outline_spinner.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <corners android:radius="@dimen/small_margin" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray_200" />
+</shape>

--- a/app/src/main/res/layout/fragment_address_type.xml
+++ b/app/src/main/res/layout/fragment_address_type.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/included_toolbar"
+        layout="@layout/include_toolbar" />
+
+    <TextView
+        android:id="@+id/address_label_new_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin"
+        android:paddingHorizontal="@dimen/margin"
+        android:text="@string/address_label_type_selector"
+        android:textAppearance="?attr/textAppearanceListItem"
+        app:layout_constraintTop_toBottomOf="@id/included_toolbar" />
+
+    <FrameLayout
+        android:id="@+id/location_type_selector_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/big_margin"
+        android:layout_marginTop="@dimen/margin"
+        android:layout_marginEnd="@dimen/big_margin"
+        android:background="@drawable/outline_spinner"
+        android:minHeight="?attr/listPreferredItemHeightSmall"
+        app:layout_constraintEnd_toStartOf="@id/loading_indicator"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/address_label_new_type">
+
+        <Spinner
+            android:id="@+id/location_type_selector"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:minHeight="@dimen/minimum_touch_size"
+            tools:ignore="SpeakableTextPresentCheck" />
+    </FrameLayout>
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/loading_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/big_margin"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="@id/location_type_selector_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/location_type_selector_layout"
+        app:layout_constraintTop_toTopOf="@id/location_type_selector_layout" />
+
+    <TextView
+        android:id="@+id/label_retry"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin"
+        android:layout_marginTop="@dimen/margin"
+        android:text="@string/address_error_location_type"
+        android:textColor="?attr/colorError"
+        android:textStyle="italic"
+        app:layout_constraintEnd_toStartOf="@id/btn_retry"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/location_type_selector_layout" />
+
+    <ImageButton
+        android:id="@+id/btn_retry"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin"
+        android:background="@null"
+        android:contentDescription="@string/address_cd_btn_retry_for_location"
+        app:layout_constraintBottom_toBottomOf="@id/label_retry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/label_retry"
+        app:layout_constraintTop_toTopOf="@id/label_retry"
+        app:srcCompat="@drawable/ic_refresh" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/retry_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="btn_retry,label_retry"
+        tools:visibility="visible" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_start_address_setup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin"
+        android:layout_marginEnd="@dimen/margin"
+        android:layout_marginBottom="@dimen/margin"
+        android:enabled="false"
+        android:text="@string/address_btn_start_address_setup"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/configure_addresses.xml
+++ b/app/src/main/res/navigation/configure_addresses.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/configure_addresses"
     app:startDestination="@id/create_addresses">
 
@@ -50,7 +51,15 @@
                 android:defaultValue="false"
                 app:argType="boolean" />
         </action>
+        <action
+            android:id="@+id/action_navigate_save_address_to_addressTypeFragment"
+            app:destination="@id/addressTypeFragment" />
 
     </fragment>
+    <fragment
+        android:id="@+id/addressTypeFragment"
+        android:name="ro.code4.deurgenta.ui.address.AddressTypeFragment"
+        tools:layout="@layout/fragment_address_type"
+        android:label="@string/address_title_new_type" />
 
 </navigation>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -169,6 +169,13 @@
     </string>
     <string name="configure_another_address_header">Configureaza alta adresa.</string>
     <string name="save_home_address">Adresa ta de domiciliu a fost salvata cu success.</string>
+    <string name="address_title_new_type">Configurează o altă adresă</string>
+    <string name="address_label_type_selector">Alege tipul adresei</string>
+    <string name="address_btn_start_address_setup">Continuă</string>
+    <string name="address_cd_btn_retry_for_location">Reîncercă afișarea locațiilor</string>
+    <string name="address_error_location_type">Tipurile de locații nu au putut fi încărcate. Te rugăm să
+        încerci din nou!</string>
+    <string name="address_location_pick">Alege</string>
 
     <!-- Permissions -->
     <string name="permission_rationale">Localizarea necesitate permisiune deoarece este functionalitatea de baza.</string>

--- a/app/src/main/res/values/analytics_strings.xml
+++ b/app/src/main/res/values/analytics_strings.xml
@@ -13,4 +13,5 @@
     <string name="analytics_title_courses_filtering" translatable="false">Courses Filtering</string>
     <string name="analytics_title_courses_listing" translatable="false">Courses Listing</string>
     <string name="analytics_title_courses_details" translatable="false">Course Details</string>
+    <string name="analytics_title_address_type" translatable="false">Address type</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,6 +10,7 @@
 
     <dimen name="small_icon_size">16dp</dimen>
     <dimen name="medium_icon_size">32dp</dimen>
+    <dimen name="minimum_touch_size">48dp</dimen>
 
     <!-- Text sizes-->
     <dimen name="text_size_big">20sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,12 @@
     your saved addresses and your meeting point. </string>
     <string name="configure_another_address_header">Configure another address</string>
     <string name="save_home_address">Your home address was saved successfully.</string>
+    <string name="address_title_new_type">Configure another address</string>
+    <string name="address_label_type_selector">Pick address type</string>
+    <string name="address_btn_start_address_setup">Continue</string>
+    <string name="address_cd_btn_retry_for_location">Retry location type fetching</string>
+    <string name="address_error_location_type">Failed to retrieve location types, please try again!</string>
+    <string name="address_location_pick">Pick</string>
 
     <!-- Permissions -->
     <string name="permission_rationale">Location permission is needed for core functionality.</string>

--- a/app/src/sharedTest/java/ro/code4/deurgenta/utils/TestSchedulersProvider.kt
+++ b/app/src/sharedTest/java/ro/code4/deurgenta/utils/TestSchedulersProvider.kt
@@ -1,10 +1,11 @@
 package ro.code4.deurgenta.utils
 
-import io.reactivex.Scheduler
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.schedulers.Schedulers
 import ro.code4.deurgenta.helper.SchedulersProvider
 
 class TestSchedulersProvider : SchedulersProvider {
+
     override fun computation(): Scheduler = Schedulers.trampoline()
 
     override fun io(): Scheduler = Schedulers.trampoline()


### PR DESCRIPTION
Changes in this PR :
- closes #48 , the locations are retrieved from the API, the user has the option to retry fetching the locations if the automatic fetch fails and no local location types are available locally in the database.
- partially implements #12 . The UI is mostly the same as the mockup with  the exception of the initial "alege" text(which I think is unneeded as we already have a label to tell the user what to do) and the icons, for which I don't know how to make the match between the location type and its icon. Also, this new fragment isn't completely bound to the on boarding graph: it will be started from the "Save address screen"(03.06) but currently doesn't start the map location selection(03.03)(because it will require substantial changes).
